### PR TITLE
fix(bin): Fix load path for .bobconfigrc

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,13 +1,14 @@
 const cosmiconfig = require('cosmiconfig');
 
 function getConfig() {
+    let configFile = path.join(__dirname, '../.bobconfigrc');
     let cosmiConfig = cosmiconfig('bobconfig', {
         cache: false,
         format: 'json',
         sync: true
     });
 
-    return cosmiConfig.loadSync('./.bobconfigrc').config;
+    return cosmiConfig.loadSync(configFile).config;
 }
 
 module.exports = getConfig;


### PR DESCRIPTION
Load `.bobconfigrc` from the node module path