### PR TITLE
Fix copyDirectory throwing error when running on Windows

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,7 +28,7 @@ function copyDirectory(sourceDir, destDir) {
 
         // Do not copy .DS_Store files
         files.filter(function(file) {
-            let currentFile = file.substr(file.lastIndexOf('/') + 1);
+            let currentFile = file.substr(file.lastIndexOf(path.sep) + 1);
             if (currentFile !== '.DS_Store') {
                 fse.copySync(file, destDir + currentFile);
             }


### PR DESCRIPTION
When I build https://github.com/mdn/interactive-example on a Windows machine (`npm run build`), it will return failure on the `copyDirectory` step. Here are the logs.

```
MDN-BOB: Cleaning or creating ./docs/....
MDN-BOB: Copying static assets....
MDN-BOB: Compiling editor JavaScript....
D:\path-to-interactive-examples\node_modules\fs-extra\lib\mkdirs\mkdirs-sync.js:20
    throw errInval
    ^

Error: D:\path-to-interactive-examples\docs\media\D:\path-to-interactive-examples\node_modules\mdn-bob\editor contains invalid WIN32 path characters.
    at mkdirsSync (D:\path-to-interactive-examples\node_modules\fs-extra\lib\mkdirs\mkdirs-sync.js:18:22)
    at mkdirsSync (D:\path-to-interactive-examples\node_modules\fs-extra\lib\mkdirs\mkdirs-sync.js:36:14)
    at Object.copySync (D:\path-to-interactive-examples\node_modules\fs-extra\lib\copy-sync\copy-sync.js:30:35)
    at D:\path-to-interactive-examples\node_modules\mdn-bob\lib\utils.js:33:21
    at Array.filter (<anonymous>)
    at D:\path-to-interactive-examples\node_modules\mdn-bob\lib\utils.js:30:15
    at done (D:\path-to-interactive-examples\node_modules\node-dir\lib\paths.js:61:5)
    at D:\path-to-interactive-examples\node_modules\node-dir\lib\paths.js:118:11
    at FSReqWrap.oncomplete (fs.js:153:5)
```

A quick debugging points out to the `copyDirectory` function of "bob" package at `lib/utils.js`, specifically this chunk of codes:

```
// Do not copy .DS_Store files
files.filter(function(file) {
    let currentFile = file.substr(file.lastIndexOf('/') + 1); // <-- This line causes that error, explanation below
    if (currentFile !== '.DS_Store') {
        fse.copySync(file, destDir + currentFile);
    }
});
```

That line was problematic because it assumes that the path is separated by a `/` (POSIX), whereas in Windows, it is separated by a `\`. I change it to use Node.js's API [`path.sep`](https://nodejs.org/api/path.html#path_path_sep) that will return `\` on Windows, and `/` on POSIX

Doing that change (directly on the bob folder inside interactive-example's node_modules) makes my build successful.