### PR TITLE
Don't specify the origin for postMessage or check origins on message events

### DIFF
--- a/editor/js/editor-libs/analytics.js
+++ b/editor/js/editor-libs/analytics.js
@@ -5,12 +5,11 @@ module.exports = {
      */
     trackEvent: function(eventDetails) {
         'use strict';
-        window.parent.postMessage(
-            eventDetails,
-            window.ieConfig && window.ieConfig.origin
-                ? window.ieConfig.origin
-                : 'https://developer.mozilla.org'
-        );
+        // We use '*' as the origin so that we can post messages to
+        // developer.mozilla.org or wiki.developer.mozilla.org or the
+        // staging site. There is no confidential data being sent so
+        // this is not a security risk.
+        window.parent.postMessage(eventDetails, '*');
     },
     /**
      * Creates an object that is passed to trackEvent, recording

--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -93,18 +93,13 @@ function addPostMessageListener() {
     window.addEventListener(
         'message',
         function(event) {
-            var expectedOrigin =
-                window.ieConfig && window.ieConfig.origin
-                    ? window.ieConfig.origin
-                    : 'https://developer.mozilla.org';
-            var isExpectedOrigin = event.origin === expectedOrigin;
-
-            /* there may be other post messages so, ensure that the origin is as
-            expected and, that `event.data` contains an `smallViewport` property */
-            if (
-                isExpectedOrigin &&
-                typeof event.data.smallViewport !== undefined
-            ) {
+            // Ignore any events that don't define the smallViewport property.
+            // Note that we are not checking the origin property to verify
+            // the source of the message. This is because we can't know if
+            // we're on developer.mozilla.org or wiki.developer.mozilla.org.
+            // Since we're just setting a CSS style based on the message
+            // there is no security risk.
+            if (event.data.smallViewport !== undefined) {
                 var editorWrapper = document.querySelector('.editor-wrapper');
 
                 if (event.data.smallViewport) {

--- a/editor/js/editor-libs/mce-utils.js
+++ b/editor/js/editor-libs/mce-utils.js
@@ -66,12 +66,11 @@ module.exports = {
      * @param {Object} perf - The performance object sent to Kuma
      */
     postToKuma: function(perf) {
-        window.parent.postMessage(
-            perf,
-            window.ieConfig && window.ieConfig.origin
-                ? window.ieConfig.origin
-                : 'https://developer.mozilla.org'
-        );
+        // We use '*' as the origin so that we can post messages to
+        // developer.mozilla.org or wiki.developer.mozilla.org or the
+        // staging site. There is no confidential data being sent so
+        // this is not a security risk.
+        window.parent.postMessage(perf, '*');
     },
     /**
      * Interrupts the default click event on relative links inside

--- a/editor/js/editor-libs/perf.js
+++ b/editor/js/editor-libs/perf.js
@@ -1,53 +1,18 @@
 'use strict';
 
 /**
- * Setup the global configuration
- * Override the target origin with ?origin=<origin URL>
- * This uses URLSearchParams, which is supported in modern browsers.
- * No polyfill or fallback is provided, because this override is for
- * development and testing.
- * https://stackoverflow.com/a/979995/10612
- */
-function setupConfig() {
-    var origin = 'https://developer.mozilla.org';
-    if (window.URL) {
-        var url = new URL(window.location.href);
-        if (url.searchParams) {
-            var param = url.searchParams.get('origin');
-            if (param) {
-                origin = param;
-            }
-        }
-    }
-    window.ieConfig = {
-        origin: origin
-    };
-}
-
-/**
  * Posts a name to set as a mark to Kuma for
  * processing and beaconing to GA
  * @param {Object} perf - The performance object sent to Kuma
  */
 function postToKuma(perf) {
-    window.parent.postMessage(perf, window.ieConfig.origin);
-
-    // We're experimenting with a new UX for MDN on beta.developer.mozilla.org
-    // and really want to get these perf metrics for interactive examples
-    // when they are displayed on the new beta domain. But the origin is
-    // built into the rendered HTML that is shared by the beta and non-beta
-    // sites, so the postMessage call above will fail silently if we're
-    // embedded within a page on the beta site. As a hacky workaround
-    // we post the message again, with a 'beta.' prefix added to the origin.
-    //
-    // TODO(djf): remove this second postMessage() when the beta
-    // site becomes the main site
-    var originParts = window.ieConfig.origin.split('://');
-    var betaOrigin = originParts[0] + '://beta.' + originParts[1];
-    window.parent.postMessage(perf, betaOrigin);
+    // We use '*' as the origin so that we can post messages to
+    // developer.mozilla.org or wiki.developer.mozilla.org or the
+    // staging site. There is no confidential data being sent so
+    // this is not a security risk.
+    window.parent.postMessage(perf, '*');
 }
 
-setupConfig();
 postToKuma({ markName: 'interactive-editor-loading' });
 
 /**


### PR DESCRIPTION
My last PR to this repo modified perf.js to call postMessage()
twice so that data would be sent to the beta domain while we're
supporting that domain. This turns out to be problematic because:

- there were two other postMessage() calls that did not get
  the same treatment, so we still weren't getting the data we
  needed on the beta domain

- sending extra messages causes angry messages in the developer console

- this hack for the beta domain was temporary because the beta
  domain is going away. But we'll have the same problem with the
  wiki domain, and that isn't going away any time soon, so we need
  a more general solution.

So in this PR, I've found all postMessage() calls and message
event handlers and have removed the origin checks. This means that
interactive examples will be able to communicate with the document
in which they are embedded regardless of the origin of that document.
Since there is no sensitive information being exchanged, this should
not be a security issue.