### PR TITLE
Add support for BigInts in js console

### DIFF
--- a/editor/js/editor-libs/console-utils.js
+++ b/editor/js/editor-libs/console-utils.js
@@ -41,7 +41,7 @@ module.exports = {
     formatObject: function(input) {
         'use strict';
         var bufferDataViewRegExp = /^(ArrayBuffer|SharedArrayBuffer|DataView)$/;
-        var complexArrayRegExp = /^(Int8Array|Int16Array|Int32Array|Uint8Array|Uint16Array|Uint32Array|Uint8ClampedArray|Float32Array|Float64Array)$/;
+        var complexArrayRegExp = /^(Int8Array|Int16Array|Int32Array|Uint8Array|Uint16Array|Uint32Array|Uint8ClampedArray|Float32Array|Float64Array|BigInt64Array|BigUint64Array)$/;
         var objectName = input.constructor.name;
 
         if (objectName === 'String') {
@@ -112,6 +112,8 @@ module.exports = {
                 return '-0';
             }
             return String(input);
+        } else if (typeof input === 'bigint') {
+            return String(input) + 'n';
         } else if (typeof input === 'string') {
             // string literal
             return '"' + input + '"';


### PR DESCRIPTION
I had no idea how complex interactive-examples and this lib "bob" is. Holy moly!

Anyway, this is an untested attempt to make the JS console support BigInt.

Per the BigInt ECMAScript proposal, if you call the the `toString` operation on `BigInt` types, it will not have the trailing "n". I believe this is not very useful for us, as the browser consoles are displaying it and it is useful to actually see the bigint type in our samples, I believe.

Then this also adds the bigint typed array types, which also should get the same nice formatting as the other typed arrays.