### PR TITLE
Print detailed error messages during build

### DIFF
--- a/lib/mdn-bob.js
+++ b/lib/mdn-bob.js
@@ -18,8 +18,8 @@ function init() {
     // empty or create `config.baseDir`
     fse.emptyDir(config.baseDir, error => {
         if (error) {
-            console.error('MDN-BOB: (mdn-bob.js/@init) ${error}');
-            throw new Error('MDN-BOB: (mdn-bob.js/@init) ${error}');
+            console.error(`MDN-BOB: (mdn-bob.js/@init) ${error}`);
+            throw new Error(`MDN-BOB: (mdn-bob.js/@init) ${error}`);
         }
 
         console.info('MDN-BOB: Copying static assets....');
@@ -56,7 +56,7 @@ function init() {
                     });
             },
             reason => {
-                console.error('MDN-BOB: (bundler.js/@compileJS) ${reason}');
+                console.error(`MDN-BOB: (bundler.js/@compileJS) ${reason}`);
             }
         );
     });


### PR DESCRIPTION
As I've seen in two error handlers we just print `${error}` as a string which was strange to me.
Maybe it is just a typo so I would like to fix them.

If it intentionally behaves like this then please close this pull request.