### PR TITLE
Enable bob to understand standalone JS files for JS examples

### DIFF
--- a/lib/pageBuilder.js
+++ b/lib/pageBuilder.js
@@ -33,7 +33,6 @@ function build(pages) {
         let tmpl = pageBuilderUtils.getPageTmpl(type);
         let outputHTML = '';
 
-        const exampleCode = fse.readFileSync(currentPage.exampleCode, 'utf8');
         const outputPath =
             config.pagesDir + currentPage.type + '/' + currentPage.fileName;
 
@@ -68,19 +67,12 @@ function build(pages) {
             // set main title
             tmpl = pageBuilderUtils.setMainTitle(currentPage, tmpl);
 
-            if (currentPage.type === 'html') {
-                let processedHTML = processor.preprocessHTML(exampleCode);
-                /* Note: Using String.prototype.replace's replacement function instead of
-                replacement string at 2nd argument because replacement string has weird
-                behavior to $ (dollar sign). More info:
-                https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter */
-                outputHTML = tmpl.replace(
-                    '%example-code%',
-                    () => processedHTML
-                );
-            } else {
-                outputHTML = tmpl.replace('%example-code%', () => exampleCode);
-            }
+            const exampleCode = processor.processExampleCode(
+                currentPage.type,
+                currentPage.exampleCode
+            );
+            
+            outputHTML = tmpl.replace('%example-code%', () => exampleCode);
 
             fse.outputFileSync(outputPath, outputHTML);
         }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -79,13 +79,25 @@ function processInclude(type, tmpl, source) {
         : processJSInclude(tmpl, source);
 }
 
+function getJSExampleHeightByLineCount(lineCount) {
+    if(lineCount < 10) {
+        return 'shorter';
+    }
+    if(lineCount > 13) {
+        return 'taller';
+    }
+    return '';
+}
+
 /**
  * Process the example source code, based on its type.
  * @param {String} exampleCode - The example source code itself
  * @returns {String} jsExample - The example wrapped into code tag
  */
-function wrapJSExampleIntoHtml(exampleCode) {
-    return `<pre><code id="static-js">${exampleCode}</code></pre>`;
+function preprocessJSExample(exampleCode) {
+    const lineCount = (exampleCode.match(/\n/g) || []).length + 1;
+    const height = getJSExampleHeightByLineCount(lineCount);
+    return `<pre><code id="static-js" data-height="${height}">${exampleCode}</code></pre>`;
 }
 
 /**
@@ -102,7 +114,8 @@ function processExampleCode(type, sourcePath) {
         case 'css':
             return exampleCode;
         case 'js':
-            return wrapJSExampleIntoHtml(exampleCode);
+            // if .html return file
+            return preprocessJSExample(exampleCode);
         default:
             return '';
     }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -79,7 +79,37 @@ function processInclude(type, tmpl, source) {
         : processJSInclude(tmpl, source);
 }
 
+/**
+ * Process the example source code, based on its type.
+ * @param {String} exampleCode - The example source code itself
+ * @returns {String} jsExample - The example wrapped into code tag
+ */
+function wrapJSExampleIntoHtml(exampleCode) {
+    return `<pre><code id="static-js">${exampleCode}</code></pre>`;
+}
+
+/**
+ * Process the example source code, based on its type.
+ * @param {String} type - `html`, `js`, or `css`
+ * @param {String} sourcePath - The path of the source code
+ * @returns {String} example - The embeddable example
+ */
+function processExampleCode(type, sourcePath) {
+    const exampleCode = fse.readFileSync(sourcePath, 'utf8');
+    switch (type) {
+        case 'html':
+            return preprocessHTML(exampleCode);
+        case 'css':
+            return exampleCode;
+        case 'js':
+            return wrapJSExampleIntoHtml(exampleCode);
+        default:
+            return '';
+    }
+}
+
 module.exports = {
     preprocessHTML,
-    processInclude
+    processInclude,
+    processExampleCode
 };

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -5,7 +5,7 @@ const uglify = require('uglify-es');
 const getConfig = require('./config');
 const config = getConfig();
 
-const MAX_LINE_COUNT_OF_SHORT_JS_EXAMPLES = 10;
+const MAX_LINE_COUNT_OF_SHORT_JS_EXAMPLES = 7;
 const MIN_LINE_COUNT_OF_TALL_JS_EXAMPLES = 14;
 
 /**

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -115,7 +115,9 @@ function processExampleCode(type, sourcePath) {
             return exampleCode;
         case 'js':
             // if .html return file
-            return preprocessJSExample(exampleCode);
+            return sourcePath.endsWith('html') 
+              ? exampleCode
+              : preprocessJSExample(exampleCode);
         default:
             return '';
     }

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -5,8 +5,8 @@ const uglify = require('uglify-es');
 const getConfig = require('./config');
 const config = getConfig();
 
-const MAX_LINE_COUNT_OF_SHORT_EXAMPLES = 10;
-const MIN_LINE_COUNT_OF_TALL_EXAMPLES = 14;
+const MAX_LINE_COUNT_OF_SHORT_JS_EXAMPLES = 10;
+const MIN_LINE_COUNT_OF_TALL_JS_EXAMPLES = 14;
 
 /**
  * A super simple preprocessor that converts < to &lt;
@@ -88,10 +88,10 @@ function processInclude(type, tmpl, source) {
  * @returns height - the value of the data-height property
  */
 function getJSExampleHeightByLineCount(lineCount) {
-    if(lineCount <= MAX_LINE_COUNT_OF_SHORT_EXAMPLES) {
+    if(lineCount <= MAX_LINE_COUNT_OF_SHORT_JS_EXAMPLES) {
         return 'shorter';
     }
-    if(lineCount >= MIN_LINE_COUNT_OF_TALL_EXAMPLES) {
+    if(lineCount >= MIN_LINE_COUNT_OF_TALL_JS_EXAMPLES) {
         return 'taller';
     }
     return '';

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -5,6 +5,9 @@ const uglify = require('uglify-es');
 const getConfig = require('./config');
 const config = getConfig();
 
+const MAX_LINE_COUNT_OF_SHORT_EXAMPLES = 10;
+const MIN_LINE_COUNT_OF_TALL_EXAMPLES = 14;
+
 /**
  * A super simple preprocessor that converts < to &lt;
  * @param {String} html - The HTML as a string
@@ -79,11 +82,16 @@ function processInclude(type, tmpl, source) {
         : processJSInclude(tmpl, source);
 }
 
+/**
+ * Returns the height of the example block based on the line count
+ * @param {Number} lineCount - Count of lines in the source code
+ * @returns height - the value of the data-height property
+ */
 function getJSExampleHeightByLineCount(lineCount) {
-    if(lineCount < 10) {
+    if(lineCount <= MAX_LINE_COUNT_OF_SHORT_EXAMPLES) {
         return 'shorter';
     }
-    if(lineCount > 13) {
+    if(lineCount >= MIN_LINE_COUNT_OF_TALL_EXAMPLES) {
         return 'taller';
     }
     return '';
@@ -114,10 +122,9 @@ function processExampleCode(type, sourcePath) {
         case 'css':
             return exampleCode;
         case 'js':
-            // if .html return file
-            return sourcePath.endsWith('html') 
-              ? exampleCode
-              : preprocessJSExample(exampleCode);
+            return sourcePath.endsWith('.js') 
+              ? preprocessJSExample(exampleCode)
+              : exampleCode;
         default:
             return '';
     }
@@ -126,5 +133,5 @@ function processExampleCode(type, sourcePath) {
 module.exports = {
     preprocessHTML,
     processInclude,
-    processExampleCode
+    processExampleCode,
 };

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -88,10 +88,11 @@ function processInclude(type, tmpl, source) {
  * @returns height - the value of the data-height property
  */
 function getJSExampleHeightByLineCount(lineCount) {
-    if(lineCount <= MAX_LINE_COUNT_OF_SHORT_JS_EXAMPLES) {
+    if (lineCount <= MAX_LINE_COUNT_OF_SHORT_JS_EXAMPLES) {
         return 'shorter';
     }
-    if(lineCount >= MIN_LINE_COUNT_OF_TALL_JS_EXAMPLES) {
+
+    if (lineCount >= MIN_LINE_COUNT_OF_TALL_JS_EXAMPLES) {
         return 'taller';
     }
     return '';


### PR DESCRIPTION
This pull request aims to support both `.js` and `.html` source files for the javascript live examples based on #367 