### PR TITLE
fix(dependency): fix incorrect CodeMirror references

### DIFF
--- a/editor/tmpl/live-js-tmpl.html
+++ b/editor/tmpl/live-js-tmpl.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>%title%</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="../../css/codemirror-5-31-0.css" rel="stylesheet" />
+    <link href="../../css/codemirror-5-50-2.css" rel="stylesheet" />
     <link href="../../css/editor-js.css" rel="stylesheet" />
     %example-css-src%
     <script>%inject-perf%</script>
@@ -30,7 +30,7 @@
 
     %example-js-src%
 
-    <script src="../../js/codemirror-5-31-0.js"></script>
+    <script src="../../js/codemirror-5-50-2.js"></script>
     <script src="../../js/editor-js.js"></script>
   </body>
 </html>

--- a/editor/tmpl/live-tabbed-tmpl.html
+++ b/editor/tmpl/live-tabbed-tmpl.html
@@ -5,7 +5,7 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>%title%</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="../../css/codemirror-tabbed-5-31-0.css" rel="stylesheet" />
+    <link href="../../css/codemirror-tabbed-5-50-2.css" rel="stylesheet" />
     <link href="../../css/editor-tabbed.css" rel="stylesheet" />
     <script>%inject-perf%</script>
   </head>
@@ -51,7 +51,7 @@
           <div id="console" class="console"><code></code></div>
       </section>
 
-    <script src="../../js/codemirror-tabbed-5-31-0.js"></script>
+    <script src="../../js/codemirror-tabbed-5-50-2.js"></script>
     <script src="../../js/editor-tabbed.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Fixes CSS and JS references still referencing old version of CodeMirror

Fixes #394