### PR TITLE
refactor: cache buster on static assets in rendered html

### DIFF
--- a/editor/tmpl/live-css-tmpl.html
+++ b/editor/tmpl/live-css-tmpl.html
@@ -5,8 +5,8 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>%title%</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="../../css/css-examples-libs-1-8-4.css" />
-    <link rel="stylesheet" href="../../css/editor-css.css" />
+    <link rel="stylesheet" href="../../css/css-examples-libs-1-8-4.css%cache-buster%" />
+    <link rel="stylesheet" href="../../css/editor-css.css%cache-buster%" />
     %example-css-src%
     <script>%inject-perf%</script>
   </head>
@@ -21,8 +21,8 @@
         </div>
     </section>
     <div id="user-message" class="user-message" aria-hidden="true">Copied!</div>
-    <script src="../../js/css-examples-libs-1-8-4.js"></script>
-    <script src="../../js/editor-css.js"></script>
+    <script src="../../js/css-examples-libs-1-8-4.js%cache-buster%"></script>
+    <script src="../../js/editor-css.js%cache-buster%"></script>
     %example-js-src%
   </body>
 </html>

--- a/editor/tmpl/live-js-tmpl.html
+++ b/editor/tmpl/live-js-tmpl.html
@@ -5,8 +5,8 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>%title%</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="../../css/codemirror-5-50-2.css" rel="stylesheet" />
-    <link href="../../css/editor-js.css" rel="stylesheet" />
+    <link href="../../css/codemirror-5-50-2.css%cache-buster%" rel="stylesheet" />
+    <link href="../../css/editor-js.css%cache-buster%" rel="stylesheet" />
     %example-css-src%
     <script>%inject-perf%</script>
   </head>
@@ -30,7 +30,7 @@
 
     %example-js-src%
 
-    <script src="../../js/codemirror-5-50-2.js"></script>
-    <script src="../../js/editor-js.js"></script>
+    <script src="../../js/codemirror-5-50-2.js%cache-buster%"></script>
+    <script src="../../js/editor-js.js%cache-buster%"></script>
   </body>
 </html>

--- a/editor/tmpl/live-tabbed-tmpl.html
+++ b/editor/tmpl/live-tabbed-tmpl.html
@@ -5,8 +5,8 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <title>%title%</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="../../css/codemirror-tabbed-5-50-2.css" rel="stylesheet" />
-    <link href="../../css/editor-tabbed.css" rel="stylesheet" />
+    <link href="../../css/codemirror-tabbed-5-50-2.css%cache-buster%" rel="stylesheet" />
+    <link href="../../css/editor-tabbed.css%cache-buster%" rel="stylesheet" />
     <script>%inject-perf%</script>
   </head>
   <body>
@@ -51,7 +51,7 @@
           <div id="console" class="console"><code></code></div>
       </section>
 
-    <script src="../../js/codemirror-tabbed-5-50-2.js"></script>
-    <script src="../../js/editor-tabbed.js"></script>
+    <script src="../../js/codemirror-tabbed-5-50-2.js%cache-buster%"></script>
+    <script src="../../js/editor-tabbed.js%cache-buster%"></script>
   </body>
 </html>

--- a/lib/pageBuilder.js
+++ b/lib/pageBuilder.js
@@ -1,3 +1,7 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
 const fse = require('fs-extra');
 const glob = require('glob');
 
@@ -24,7 +28,7 @@ const config = getConfig();
  * }
  *
  */
-function build(pages) {
+function build(pages, selfVersion = '') {
     for (let page in pages) {
         let currentPage = pages[page];
         let cssSource = currentPage.cssExampleSrc;
@@ -38,6 +42,9 @@ function build(pages) {
 
         // inject the perf script in the head of the template
         tmpl = pageBuilderUtils.injectPerf(tmpl);
+
+        // Inject the cache buster
+        tmpl = pageBuilderUtils.setCacheBuster(`?v=${selfVersion}`, tmpl);
 
         // handle both standard and webapi tabbed examples
         if (type.indexOf('tabbed') > -1) {
@@ -80,17 +87,42 @@ function build(pages) {
 }
 
 /**
+ * Return a (short) string that indicates what verion of this tool we're
+ * running. Because the `package.json` doesn't necessarily change between
+ * versions we need to gather both from that and from the relevant .js files.
+ */
+function getSelfVersion(length = 7) {
+    const root = path.resolve(__dirname, '..');
+    const filepaths = [
+        path.join(root, 'package.json'),
+        // This is broad but let's make it depend on every .js file
+        // in this file's folder
+        ...glob.sync(path.join(root, 'lib', '**', '*.js')),
+        // And every every other file too
+        ...glob.sync(path.join(root, 'editor', '**', '*.js')),
+        ...glob.sync(path.join(root, 'editor', '**', '*.css')),
+        ...glob.sync(path.join(root, 'editor', '**', '*.html'))
+    ];
+    const hasher = crypto.createHash('md5');
+    filepaths
+        .map(fp => fs.readFileSync(fp, 'utf8'))
+        .forEach(content => hasher.update(content));
+    return hasher.digest('hex').slice(0, length);
+}
+
+/**
  * Iterates over all `meta.json` files. For each file,
  * it passes the list of pages to the `build` function.
  */
 function buildPages() {
+    const selfVersion = getSelfVersion();
     return new Promise((resolve, reject) => {
         const metaJSONArray = glob.sync(config.metaGlob, {});
 
         for (const metaJson of metaJSONArray) {
             const file = fse.readJsonSync(metaJson);
             try {
-                build(file.pages);
+                build(file.pages, selfVersion);
             } catch (error) {
                 console.error(
                     `MDN-BOB: (pageBuilder.js/@buildPages) Error while building pages ${metaJson}: ${error}`

--- a/lib/pageBuilderUtils.js
+++ b/lib/pageBuilderUtils.js
@@ -121,9 +121,7 @@ module.exports = {
 
         if (currentPage.height === undefined) {
             console.error(
-                `[BoB] Required height property of ${
-                    currentPage.title
-                } is not defined`
+                `[BoB] Required height property of ${currentPage.title} is not defined`
             );
             process.exit(1);
         }
@@ -149,5 +147,9 @@ module.exports = {
             );
         }
         return tmpl;
+    },
+    setCacheBuster: function(string, tmpl) {
+        const regex = /%cache-buster%/g;
+        return tmpl.replace(regex, string);
     }
 };


### PR DESCRIPTION
After this:

```
▶ head -10 docs/pages/js/array-concat.html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="utf-8" />
    <meta http-equiv="x-ua-compatible" content="ie=edge" />
    <title>JavaScript Demo: Array.concat()</title>
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <link href="../../css/codemirror-5-50-2.css?v=0e360b5" rel="stylesheet" />
    <link href="../../css/editor-js.css?v=0e360b5" rel="stylesheet" />
```