### PR TITLE
refactor: the CodeMirror config for tabby also uses autoRefresh

### DIFF
--- a/bundles.json
+++ b/bundles.json
@@ -15,6 +15,7 @@
         "codeMirrorTabbed": {
             "javascript": [
                 "/node_modules/codemirror/lib/codemirror.js",
+                "/node_modules/codemirror/addon/display/autorefresh.js",
                 "/node_modules/codemirror/mode/javascript/javascript.js",
                 "/node_modules/codemirror/mode/xml/xml.js",
                 "/node_modules/codemirror/mode/css/css.js",

--- a/editor/js/editor-libs/tabby.js
+++ b/editor/js/editor-libs/tabby.js
@@ -100,7 +100,8 @@ module.exports = {
                 lineNumbers: true,
                 lineWrapping: true,
                 mode: 'htmlmixed',
-                value: staticHTMLCode.querySelector('code').textContent
+                value: staticHTMLCode.querySelector('code').textContent,
+                autoRefresh: true
             }
         },
         css: {
@@ -109,7 +110,8 @@ module.exports = {
             config: {
                 lineNumbers: true,
                 mode: 'css',
-                value: staticCSSCode.querySelector('code').textContent
+                value: staticCSSCode.querySelector('code').textContent,
+                autoRefresh: true
             }
         },
         js: {
@@ -118,7 +120,8 @@ module.exports = {
             config: {
                 lineNumbers: true,
                 mode: 'javascript',
-                value: staticJSCode.querySelector('code').textContent
+                value: staticJSCode.querySelector('code').textContent,
+                autoRefresh: true
             }
         }
     },
@@ -131,7 +134,6 @@ module.exports = {
         if (defaultTab) {
             setDefaultTab(defaultTab);
         }
-
         for (var editor of editorTypes) {
             // enable relevant tabs
             document.getElementById(editor).classList.remove('hidden');


### PR DESCRIPTION
Seems to unbreak my pages in local dev! It was breaking before but as of this change I can no longer reproduce it. Yay!