### PR TITLE
(fix) media assets directory structure

### DIFF
--- a/.bobconfigrc
+++ b/.bobconfigrc
@@ -8,7 +8,7 @@
     "examplesMediaRoot": "./live-examples/media",
     "editorMediaRoot": "../editor/media",
     "editorMediaDest": "./docs/media/",
-    "examplesMediaDest": "./docs/media/examples/",
+    "examplesMediaDest": "./docs/media/",
     "fontsMediaDest": "./docs/media/fonts/",
     "metaGlob": "./live-examples/**/meta.json",
     "pagesDir": "./docs/pages/"


### PR DESCRIPTION
Ensure media assets directory does not nest examples folder two levels deep

fix #516