### PR TITLE
Update console-utils.js

### DIFF
--- a/editor/js/editor-libs/console-utils.js
+++ b/editor/js/editor-libs/console-utils.js
@@ -97,6 +97,7 @@ module.exports = {
     /**
      * Formats output to indicate its type:
      * - quotes around strings
+     * - single quotes around strings containing double quotes
      * - square brackets around arrays
      * (also copes with arrays of arrays)
      * does NOT detect Int32Array etc
@@ -121,7 +122,11 @@ module.exports = {
             return String(input) + 'n';
         } else if (typeof input === 'string') {
             // string literal
-            return '"' + input + '"';
+            if (input.includes('"')) {
+                return "'" + input + "'";
+            } else {
+                return '"' + input + '"';   
+            }
         } else if (Array.isArray(input)) {
             // check the contents of the array
             return 'Array [' + this.formatArray(input) + ']';


### PR DESCRIPTION
Potential fix for mdn/sprints#2822
Since the result of JSON.stringify includes a double quote `"`, then the string will be wrapped with single quotes, making the output valid.

Note that this is not an ideal fix as a string containing both `"` and `'` will get be wrapped with single quotes. However, this can be considered an improvement.

Right now, you can simulate the issue by running: `console.log('Hello "Sam"')`. You will get `"Hello "Sam""`. This PR will correct the output to `'Hello "Sam"'`