### PR TITLE
fix: add workflows for new issues and pull requests

### DIFF
--- a/.github/workflows/opened-issues-triage.yml
+++ b/.github/workflows/opened-issues-triage.yml
@@ -1,0 +1,15 @@
+name: Move new issues into Issues Awaiting Triage
+
+on:
+    issues:
+        types: [opened]
+
+jobs:
+    automate-project-columns:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: alex-page/github-project-automation-plus@v0.8.1
+              with:
+                  project: MDN Web Docs
+                  column: Issues Awaiting Triage
+                  repo-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/opened-pull-requests.yml
+++ b/.github/workflows/opened-pull-requests.yml
@@ -1,0 +1,15 @@
+name: Move opened pull requests to Ready for Review
+
+on:
+    pull_request:
+        types: [opened]
+
+jobs:
+    automate-project-columns:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: alex-page/github-project-automation-plus@v0.8.1
+              with:
+                  project: MDN Web Docs
+                  column: Ready for Review
+                  repo-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Adds two new workflows:

1. Newly opened issues are added to the MDN Web Docs project and moved into the Issues Awaiting Triage column
2. Newly opened pull requests are added to the MDN Web Docs project and moved into the Ready for Review column