### PR TITLE
chore: use reusable auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,14 +1,8 @@
-name: auto-merge
-
-on:
-    pull_request:
+name: "auto-merge"
+on: [pull_request_target]
 
 jobs:
-    auto-merge:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: ahmadnassri/action-dependabot-auto-merge@v2
-              with:
-                  target: minor
-                  github-token: ${{ secrets.GH_TOKEN }}
+  auto-merge:
+    uses: mdn/workflows/.github/workflows/auto-merge.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Switch to reusable `auot-merge` from `workflows` repo

fix #658