### PR TITLE
Add button to each example for keyboard use

### DIFF
--- a/editor/css/editable-css.css
+++ b/editor/css/editable-css.css
@@ -94,18 +94,36 @@
     display: block;
 }
 
+.live .example-choice:before,
+.live .example-choice .example-choice-button {
+    transform: translateY(-50%);
+    position: absolute;
+    top: 50%;
+    opacity: 0;
+    border-left: 10px solid #1b76c4;
+    border-top: 10px solid transparent;
+    border-bottom: 10px solid transparent;
+}
 .live .example-choice:before {
     content: '';
+    opacity: 0;
+    transition: all .2s ease-out;
+    transform: translateY(-50%);
     position: absolute;
     top: 50%;
     right: -10px;
     z-index: 1;
-    opacity: 0;
-    transition: all .2s ease-out;
-    transform: translateY(-50%);
-    border-left: 10px solid #1b76c4;
-    border-top: 10px solid transparent;
-    border-bottom: 10px solid transparent;
+}
+.live .example-choice .example-choice-button {
+    background-color: transparent;
+    border-left-color: #666;
+    outline-offset: 2px;
+    border-right: 0;
+    padding: 0;
+    right: -1.5em;
+}
+.live .example-choice .example-choice-button:focus {
+    opacity: 1;
 }
 
 .example-choice.selected:before {

--- a/editor/js/editable-css.js
+++ b/editor/js/editable-css.js
@@ -22,6 +22,16 @@
 
     for (var i = 0, l = exampleChoices.length; i < l; i++) {
       var exampleChoice = exampleChoices[i];
+      var choiceButton = document.createElement('button');
+      var choiceButtonText = document.createElement('span');
+
+      choiceButton.setAttribute("type", "button");
+      choiceButton.classList.add("example-choice-button")
+      choiceButtonText.classList.add("visually-hidden");
+      choiceButtonText.textContent = "Choose example " + ( i + 1);
+
+      choiceButton.append(choiceButtonText);
+      exampleChoice.append(choiceButton);
 
       originalChoices.push(exampleChoice.querySelector("code").textContent);
 


### PR DESCRIPTION
This dynamically adds a button to each example choice:

* styled as the arrow that indicated current choice, but in gray. If someone uses a keyboard
* in tab order with 0 opacity (it will visually show once it has focus)
* it can be activated with just a keyboard like any button
* it has an accessible name of “Choose example x”

Example of it in use:

https://user-images.githubusercontent.com/178782/151399525-ec316351-c833-4aa1-976a-eb882f687ba2.mov

This could fix #688 