### PR TITLE
(fix:bug) Wasm examples, display errors in output

### DIFF
--- a/editor/js/editable-wat.js
+++ b/editor/js/editable-wat.js
@@ -220,7 +220,7 @@
     await wabtInitialized;
     var encoder = new TextEncoder();
     let watBuffer = encoder.encode(wat);
-    let module = wabt.parseWat("", watBuffer)
+    let module = wabt.parseWat("", watBuffer);
     module.resolveNames();
     module.validate();
     const binary = module.toBinary({ log: true, write_debug_names: true });
@@ -238,17 +238,20 @@
   async function updateOutput(wat, js) {
     output.classList.add("fade-in");
 
-    let watBlob = await compileWat(wat);
-
-    let watUrl = URL.createObjectURL(watBlob);
-
-    const exampleCode = js.replaceAll("{%wasm-url%}", watUrl);
-
     try {
-      // Create a new Function from the code, and immediately execute it.
-      new Function(exampleCode)();
-    } catch (event) {
-      output.textContent = "Error: " + event.message;
+      let watBlob = await compileWat(wat);
+
+      let watUrl = URL.createObjectURL(watBlob);
+
+      const exampleCode = js.replaceAll("{%wasm-url%}", watUrl);
+
+      // Create an new async function from the code, and immediately execute it.
+      // using an async function since WebAssembly.instantiate is async and
+      // we need to await in order to capture errors
+      let AsyncFunction = Object.getPrototypeOf(async function(){}).constructor;
+      await new AsyncFunction(exampleCode)();
+    } catch (error) {
+      console.error(error);
     }
 
     output.addEventListener("animationend", function () {

--- a/live-examples/wat-examples/statements/loop.wat
+++ b/live-examples/wat-examples/statements/loop.wat
@@ -9,17 +9,17 @@
     (loop $my_loop
 
       ;; add one to $i
-      get_global $i
+      global.get $i
       i32.const 1
       i32.add
-      set_global $i
+      global.set $i
 
       ;; log the current value of $i
-      get_global $i
+      global.get $i
       call $log
 
       ;; if $i is less than 10 branch to loop
-      get_global $i
+      global.get $i
       i32.const 10
       i32.lt_s
       br_if $my_loop


### PR DESCRIPTION
#### Compilation/syntax errors:
For that I moved the call to `compileWat` into the `try`.


#### Runtime errors:
Here we have a problem, since `WebAssembly.instantiateStreaming` is async, and the way we capture errors is by `try catch`, so unless we await the instantiation call, catch will not get the error.
So I've changed the function that runs the JS to an async function, and that is now awaited before the catch.
But if we actually want the runtime errors to show up in the output, then I'll also have to change each example to use await, something like the following
```JavaScript
var url = "{%wasm-url%}";
await WebAssembly.instantiateStreaming(fetch(url), {console});
```
For now, there is no regression, and there is the benefit of the compilation errors being displayed properly, so I think that this can be merged safely even though we need more changes for the runtime errors to be displayed.