### PR TITLE
fix:editor style cursor for light and dark modes

### DIFF
--- a/editor/css/editor-libs/common.css
+++ b/editor/css/editor-libs/common.css
@@ -285,6 +285,11 @@ body {
   border-right: 1px solid var(--border-primary);
 }
 
+.CodeMirror-cursor {
+  border-left: 1px solid white;
+  border-right: 1px solid black;
+}
+
 .user-message {
   display: none;
   position: absolute;


### PR DESCRIPTION
This sets the CodeMirror cursor to black in light mode and white in dark mode.

fix #718