### PR TITLE
Made wat examples fit nicely without scrollbar

### DIFF
--- a/editor/css/editable-js-and-wat.css
+++ b/editor/css/editable-js-and-wat.css
@@ -72,6 +72,28 @@
     min-height: 200px;
 }
 
+.wat .editor {
+    margin-bottom: 5px;
+}
+
+.wat .editor.taller,
+.wat .editor.taller .CodeMirror {
+    height: 420px;
+    min-height: 420px;
+}
+
+.wat .editor.standard,
+.wat .editor.standard .CodeMirror {
+    height: 210px;
+    min-height: 210px;
+}
+
+.wat .editor.shorter,
+.wat .editor.shorter .CodeMirror {
+    height: 140px;
+    min-height: 140px;
+}
+
 .buttons-container {
     display: flex;
     gap: 0.5rem;

--- a/editor/js/editable-wat.js
+++ b/editor/js/editable-wat.js
@@ -193,8 +193,10 @@
     /* If the `data-height` attribute is defined on the `codeBlock`, set
        the value of this attribute as a class on the editor element. */
     if (watCodeBlock.dataset["height"]) {
-      var editor = document.getElementById("wat-editor");
-      editor.classList.add(watCodeBlock.dataset["height"]);
+      var watEditor = document.getElementById("wat-panel");
+      watEditor.classList.add(watCodeBlock.dataset["height"]);
+      var jsEditor = document.getElementById("js-panel");
+      jsEditor.classList.add(watCodeBlock.dataset["height"]);
     }
 
     staticContainer = document.getElementById("static");
@@ -262,8 +264,8 @@
   /* only execute JS in supported browsers. As `document.all`
   is a non standard object available only in IE10 and older,
   this will stop JS from executing in those versions. */
-  if (!document.all && featureDetector.isDefined(exampleFeature)) {
-    document.documentElement.classList.add("js");
+  if ('WebAssembly' in window && featureDetector.isDefined(exampleFeature)) {
+    document.documentElement.classList.add("wat");
 
     initInteractiveEditor();
 

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -7,6 +7,8 @@ const config = getConfig();
 
 const MAX_LINE_COUNT_OF_SHORT_JS_EXAMPLES = 7;
 const MIN_LINE_COUNT_OF_TALL_JS_EXAMPLES = 14;
+const MAX_LINE_COUNT_OF_SHORT_WAT_EXAMPLES = 7;
+const MIN_LINE_COUNT_OF_TALL_WAT_EXAMPLES = 12;
 
 /**
  * A super simple preprocessor that converts < to &lt;
@@ -110,6 +112,23 @@ function preprocessJSExample(exampleCode) {
 }
 
 /**
+ * Returns the height of the example block based on the line count
+ * @param {Number} lineCount - Count of lines in the source code
+ * @returns height - the value of the data-height property
+ */
+function getWatExampleHeightByLineCount(lineCount) {
+    if (lineCount <= MAX_LINE_COUNT_OF_SHORT_WAT_EXAMPLES) {
+        return 'shorter';
+    }
+
+    if (lineCount >= MIN_LINE_COUNT_OF_TALL_WAT_EXAMPLES) {
+        return 'taller';
+    }
+
+    return 'standard';
+}
+
+/**
  * Process the example source code, based on its type.
  * @param {String} watCode - The example wat source code itself
  * @param {String} jsCode - The example JavaScript source code itself
@@ -117,7 +136,7 @@ function preprocessJSExample(exampleCode) {
  */
 function preprocessWatExample(watCode, jsCode) {
     const lineCount = (watCode.match(/\n/g) || []).length + 1;
-    const height = getJSExampleHeightByLineCount(lineCount);
+    const height = getWatExampleHeightByLineCount(lineCount);
     return `
         <pre><code id="static-wat" data-height="${height}">${watCode}</code></pre>
         <pre><code id="static-js" data-height="${height}">${jsCode}</code></pre>


### PR DESCRIPTION
Currently the wat/wasm examples have scrollbars as they don't fit properly in the iframe on mdn, this pr fixes this issue.

I'll still have to add the sizes (like: tall, standard, short) in the content repo after this is merged because I left that out when I first added the links to the examples.