### PR TITLE
Fix object formatting

### DIFF
--- a/editor/js/editor-libs/console-utils.js
+++ b/editor/js/editor-libs/console-utils.js
@@ -96,7 +96,7 @@ module.exports = {
         // Special object created with `OrdinaryObjectCreate(null)` returned by, for
         // example, named capture groups in https://mzl.la/2RERfQL
         // @see https://github.com/mdn/bob/issues/574#issuecomment-858213621
-        if (!objectName.constructor || !objectName.prototype) {
+        if (!input.constructor && !input.prototype) {
             var formattedChild = '';
             var start = true;
             for (var key in input) {


### PR DESCRIPTION
I think this is a fix for https://github.com/mdn/bob/issues/710.

I've confirmed that the issue there is a regression introduced in https://github.com/mdn/bob/pull/578. That PR was a fix for https://github.com/mdn/bob/issues/574, which was an error that happened with certain weird objects that don't have a constructor: https://github.com/mdn/bob/issues/574#issuecomment-840295269.

The fix was in [`formatObject()`](https://github.com/mdn/bob/blob/92e2b1e7bddbd10188bafa8c7fa7fe3c407589a1/editor/js/editor-libs/console-utils.js#L41-L115), which is a function in the mock console that takes an object to be logged and tests to see if it's any of various types that want special-case formatting. If the object isn't one of these types, then `formatObject()` just returns the original object.

The resolution for https://github.com/mdn/bob/issues/574 was to add another special case for [weird objects that don't have a constructor or a prototype](https://github.com/mdn/bob/issues/574#issuecomment-857753796), (not sure why the non-prototype bit is important) that formats these weird objects.

However, it looks like the condition to check that had an error:

```js
if (!objectName.constructor || !objectName.prototype) {
```

First because this is `||` it will be true if either condition is true, which isn't what we want (at least according to the description in the issue). But also, I think `objectName` isn't necessarily the object, it's the result of calling:

```js
var objectName = input.constructor ? input.constructor.name : input;
```

So in the case of the [`const`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const) example, `input` is a `TypeError` object, so `objectName` is a string `"TypeError"`. And then it doesn't have a prototype, so we run that special-case code, which gives us `"Object {  }"`.

What we want to happen here, I think, and what used to happen, is to skip all the special cases in this function and return `input`.

I'm guessing this will happen not only for `TypeError` but for many other types that didn't match any of the other special cases, and they will just fall through into this one.

So, I've tightened up that conditional so it's only going to catch these weird types.

I have checked that this fixes the `const` case and the others listed in https://github.com/mdn/bob/issues/710#issuecomment-1080569939, and doesn't regress https://github.com/mdn/bob/issues/574, and have tried a few other examples. But, this is tricky code as we've seen. I don't know if we have good tests for it, but it certainly needs careful review.