### PR TITLE
Not supported property values

### DIFF
--- a/editor/css/editable-css.css
+++ b/editor/css/editable-css.css
@@ -126,7 +126,7 @@
 }
 
 @media screen and (min-width: 590px) {
-  .example-choice.selected:before {
+  .example-choice.selected:before, .example-choice.invalid:before {
     opacity: 1;
     right: -1rem;
   }

--- a/editor/js/editable-css.js
+++ b/editor/js/editable-css.js
@@ -1,6 +1,7 @@
 import * as clippy from "./editor-libs/clippy.js";
 import * as mceEvents from "./editor-libs/events.js";
 import * as mceUtils from "./editor-libs/mce-utils.js";
+import * as cssEditorUtils from "./editor-libs/css-editor-utils.js";
 
 import "../css/editor-libs/ui-fonts.css";
 import "../css/editor-libs/common.css";
@@ -47,6 +48,8 @@ import "../css/editable-css.css";
     mceEvents.register();
     handleResetEvents();
     handleChoiceHover();
+    // Adding or removing class "invalid"
+    cssEditorUtils.applyInitialSupportWarningState(exampleChoices);
 
     clippy.addClippy();
   }
@@ -69,6 +72,9 @@ import "../css/editable-css.css";
         exampleChoices[i].classList.remove("selected");
         exampleChoices[i].querySelector("code").innerHTML = highlighted;
       }
+
+      // Adding or removing class "invalid"
+      cssEditorUtils.applyInitialSupportWarningState(exampleChoices);
 
       // if there is an initial choice set, set it as selected
       if (initialChoice) {

--- a/editor/js/editor-libs/css-editor-utils.js
+++ b/editor/js/editor-libs/css-editor-utils.js
@@ -1,27 +1,129 @@
 export let editTimer = undefined;
 
-export function applyCode(code, choice, targetElement) {
+export function applyCode(code, choice, targetElement, immediateInvalidChange) {
   // http://regexr.com/3fvik
   var cssCommentsMatch = /(\/\*)[\s\S]+(\*\/)/g;
   var element = targetElement || document.getElementById("example-element");
 
   // strip out any CSS comments before applying the code
-  code.replace(cssCommentsMatch, "");
+  code = code.replace(cssCommentsMatch, "");
+    // Checking if every CSS declaration in passed code, is supported by the browser
+    let codeSupported = isCodeSupported(element, code);
 
   element.style.cssText = code;
 
   // clear any existing timer
   clearTimeout(editTimer);
-  /* Start a new timer. This will ensure that the state is
-        not marked as invalid, until the user has stopped typing
-        for 500ms */
-  editTimer = setTimeout(function () {
-    if (!element.style.cssText) {
-      choice.parentNode.classList.add("invalid");
+
+  /**
+   * Adding or removing class "invalid" from choice parent, which will typically be <div class="example-choice">
+   */
+  let setInvalidClass = function() {
+    if (codeSupported) {
+      choice.parentNode.classList.remove('invalid');
     } else {
-      choice.parentNode.classList.remove("invalid");
+      choice.parentNode.classList.add('invalid');
     }
-  }, 500);
+  };
+
+  if(immediateInvalidChange) {
+    // Setting class immediately
+    setInvalidClass();
+  } else {
+    /* Start a new timer. This will ensure that the state is
+    not marked as invalid, until the user has stopped typing
+    for 500ms */
+    editTimer = setTimeout(setInvalidClass, 500);
+  }
+}
+
+/**
+ * Checks if every passed declaration is supported by the browser.
+ * In case browser recognizes property with vendor prefix(like -webkit-), lacking support for unprefixed property is ignored.
+ * Properties with vendor prefix not recognized by the browser are always ignored.
+ * @param element - any element on which cssText can be tested
+ * @param declarations - list of css declarations with no curly brackets. They need to be separated by ";" and declaration key-value needs to be separated by ":". Function expects no comments.
+ * @returns {boolean} - true if every declaration is supported by the browser. Properties with vendor prefix are excluded.
+ */
+export function isCodeSupported(element, declarations) {
+    var vendorPrefixMatch = /^-(?:webkit|moz|ms|o)-/;
+    var style = element.style;
+    // Expecting declarations to be separated by ";"
+    // Declarations with just white space are ignored
+    var declarationsArray = declarations.split(";")
+        .map(d => d.trim())
+        .filter(d => d.length > 0);
+
+    /**
+     * @returns {boolean} - true if declaration starts with -webkit-, -moz-, -ms- or -o-
+     */
+    function hasVendorPrefix(declaration) {
+        return vendorPrefixMatch.test(declaration);
+    }
+
+    /**
+     * Looks for property name by cutting off optional vendor prefix at the beginning
+     * and then cutting off rest of the declaration, starting from any whitespace or ":" in property name.
+     * @param declaration - single css declaration, with not white space at the beginning
+     * @returns {string} - property name without vendor prefix.
+     */
+    function getPropertyNameNoPrefix(declaration) {
+        var prefixMatch = vendorPrefixMatch.exec(declaration);
+        var prefix = prefixMatch === null ? "" : prefixMatch[0];
+        var declarationNoPrefix = prefix === null ? declaration : declaration.slice(prefix.length);
+        // Expecting property name to be over, when any whitespace or ":" is found
+        var propertyNameSeparator = /[\s:]/;
+        return declarationNoPrefix.split(propertyNameSeparator)[0];
+    }
+    // Clearing previous state
+    style.cssText = "";
+
+    // List of found and applied properties with vendor prefix
+    let appliedPropertiesWithPrefix = new Set();
+    // List of not applied properties - because of lack of support for its name or value
+    let notAppliedProperties = new Set();
+
+    for (let declaration of declarationsArray) {
+        let previousCSSText = style.cssText;
+        // Declarations are added one by one, because browsers sometimes combine multiple declarations into one
+        // For example Chrome changes "column-count: auto;column-width: 8rem;" into "columns: 8rem auto;"
+        style.cssText += declaration + ";"; // ";" was previous removed while using split method
+        // In case property name or value is not supported, browsers skip single declaration, while leaving rest of them intact
+        let correctlyApplied = style.cssText !== previousCSSText;
+
+        let vendorPrefixFound = hasVendorPrefix(declaration);
+        let propertyName = getPropertyNameNoPrefix(declaration);
+
+        if (correctlyApplied && vendorPrefixFound) {
+            // We are saving applied properties with prefix, so equivalent property with no prefix doesn't need to be supported
+            appliedPropertiesWithPrefix.add(propertyName);
+        } else if (!correctlyApplied && !vendorPrefixFound) {
+            notAppliedProperties.add(propertyName);
+        }
+    }
+
+    if (notAppliedProperties.size !== 0) {
+        // If property with vendor prefix is supported, we can ignore the fact that browser doesn't support property with no prefix
+        for (let substitute of appliedPropertiesWithPrefix) {
+            notAppliedProperties.delete(substitute);
+        }
+        // If any other declaration is not supported, whole block should be marked as invalid
+        if (notAppliedProperties.size !== 0)
+            return false;
+    }
+    return true;
+}
+
+/**
+ * Checking support for choices inner code and based on that information adding or removing class "invalid" from them.
+ * This function will change styles of 'example-element', so it is important to apply them again.
+ * @param choices - elements containing element code, containing css declarations to apply
+ */
+export function applyInitialSupportWarningState(choices) {
+    for(let choice of choices) {
+        let codeBlock = choice.querySelector("code");
+        applyCode(codeBlock.textContent, codeBlock.parentNode, undefined, true);
+    }
 }
 
 /**
@@ -38,7 +140,7 @@ export function choose(choice) {
   codeBlock.setAttribute("contentEditable", true);
   codeBlock.setAttribute("spellcheck", false);
 
-  applyCode(codeBlock.textContent, choice);
+  applyCode(codeBlock.textContent, codeBlock.parentNode);
 }
 
 /**
@@ -65,7 +167,7 @@ export function resetDefault() {
 }
 
 /**
- * Resets the UI state by deselcting all example choice
+ * Resets the UI state by deselecting all example choice
  */
 export function resetUIState() {
   var exampleChoiceList = document.getElementById("example-choice-list");

--- a/live-examples/css-examples/animation/animation.html
+++ b/live-examples/css-examples/animation/animation.html
@@ -4,30 +4,28 @@
   data-property="animation"
 >
   <div class="example-choice">
-    <pre><code class="language-css">position: relative;</code></pre>
+    <pre><code class="language-css">animation: slidein 3s ease-in 1s infinite reverse both running;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">postion: relative;
-    top: bananas;
-    left: banded;</code></pre>
+    <pre><code class="language-css">animation: slidein 3s linear 1s infinite running;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">transform: rotate3d(0);</code></pre>
+    <pre><code class="language-css">animation: slidein 3s linear 1s infinite alternate;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">list-style-type: "�F44D"; // thumbs up sign.</code></pre>
+    <pre><code class="language-css">animation: slidein .5s linear 1s infinite alternate;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>

--- a/live-examples/css-examples/animation/animation.html
+++ b/live-examples/css-examples/animation/animation.html
@@ -4,28 +4,30 @@
   data-property="animation"
 >
   <div class="example-choice">
-    <pre><code class="language-css">animation: slidein 3s ease-in 1s infinite reverse both running;</code></pre>
+    <pre><code class="language-css">position: relative;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">animation: slidein 3s linear 1s infinite running;</code></pre>
+    <pre><code class="language-css">postion: relative;
+    top: bananas;
+    left: banded;</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">animation: slidein 3s linear 1s infinite alternate;</code></pre>
+    <pre><code class="language-css">transform: rotate3d(0);</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>
   </div>
 
   <div class="example-choice">
-    <pre><code class="language-css">animation: slidein .5s linear 1s infinite alternate;</code></pre>
+    <pre><code class="language-css">list-style-type: "�F44D"; // thumbs up sign.</code></pre>
     <button type="button" class="copy hidden" aria-hidden="true">
       <span class="visually-hidden">Copy to Clipboard</span>
     </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16218,7 +16218,7 @@
       "version": "git+ssh://git@github.com/queengooborg/babel-plugin-prismjs.git#12605e30663aadc93dba8505229c226d5af7bd0e",
       "integrity": "sha512-CZSB7cmD86Y7Jv1Gezf9B7iY0SU5+a/sp8r+3JOneqpIUdzpUy22jPY1YL4KLBkU69TbN1DPMQsH5yaHdoR2KA==",
       "dev": true,
-      "from": "babel-plugin-prismjs@github:queengooborg/babel-plugin-prismjs#12605e30663aadc93dba8505229c226d5af7bd0e",
+      "from": "babel-plugin-prismjs@github:queengooborg/babel-plugin-prismjs#patch-1-build",
       "requires": {}
     },
     "babel-preset-current-node-syntax": {


### PR DESCRIPTION
This is fix for issues [#441](https://github.com/mdn/interactive-examples/issues/441), [#455](https://github.com/mdn/interactive-examples/issues/455) and [#354](https://github.com/mdn/interactive-examples/issues/354).

Currently when property name or its value is not supported, they are simply not being applied without any warning. Only when user changes code content, warning might be shown, but this also doesn't work when just part of declaration block is not supported.
This is quite significant, because plenty of CSS property values are currently used in interactive examples, even though they are not supported at all. This is list of values not supported by Chrome, but still displayed to those users:
```
background-position-x: right 32px;
background-position-y: bottom 32px;
text-overflow: "-"
text-overflow: ""
color: hwb(1.5708rad 20% 10% / 0.7);
image-rendering: crisp-edges;
column-fill: balance-all;
text-transform: full-width;
text-transform: full-size-kana;
word-spacing: 120%;
```

I have made not supported values, but immediately shown to the users like this:
![image](https://user-images.githubusercontent.com/100634371/164942588-d4697607-3d4e-4de1-bd31-48b8f4d30729.png)
![image](https://user-images.githubusercontent.com/100634371/164942843-2cc7b3cf-3da1-4ec5-a69b-11b799799a1b.png)


When interactive example is loaded, when reset button is used or when user types in something, it is checked whether whole declaration is property supported by the browser. This warning doesn't shown up, if unsupported property has vendor prefix or if ordinary property is not supported but its vendor prefix equivalent is supported correctly.

I have checked how my code works with every single declaration, currently being used in interactive-examples repository. You can check it by yourself by running this page: https://pastebin.com/73zGPWGG
There are 3 issues which require changing something in interactive-examples:
1. "list-style-type: "�F44D"; // thumbs up sign." uses comment which is not valid in CSS.
2. "transform: rotate3d(0)" is ignored by the browser and not applied at all, so this would need to be changed to something like 360 I think.
3. "transform: translate3d(0);" same thing

Except for that, everything seems to be ok. 

@wbamberg @schalkneethling 