### PR TITLE
fix(editor): replace margin-top on tab-list by border-top on tab

### DIFF
--- a/editor/css/editor-libs/tabby.css
+++ b/editor/css/editor-libs/tabby.css
@@ -1,7 +1,6 @@
 .tab-list {
   display: flex;
   gap: 0.5rem;
-  padding-top: 1rem;
   background: var(--background-secondary);
 }
 
@@ -11,6 +10,7 @@ button[role='tab'] {
     padding: .5em 30px;
     border: 0 none;
     border-bottom: 3px solid transparent;
+    border-top: 3px solid transparent;
     font: var(--type-emphasis-m);
     cursor: pointer;
 }


### PR DESCRIPTION
Fixes #725.

## Screenshots

### Before

<img width="796" alt="image" src="https://user-images.githubusercontent.com/495429/165993310-8c3c2142-19b6-4452-8dbc-5980c6fc4d6d.png">

### After

<img width="796" alt="image" src="https://user-images.githubusercontent.com/495429/165993602-ad915ca5-99af-4b8f-bf1d-730211d2b508.png">