### PR TITLE
Fix pasting code in CSS editor

### DIFF
--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -90,24 +90,22 @@ function copyTextOnly(event) {
 }
 
 /**
- * Handles paste events for the CSS editor. Concatenates the new text
- * from the clipboard with the existing, and syntax highlights the
- * result.
+ * Applying syntax highlights after paste event for CSS editor.
  * @param {Object} event - The paste event object
  */
 function handlePasteEvents(event) {
   "use strict";
-  var clipboardText = event.clipboardData.getData("text/plain");
-  var parentPre = event.target.offsetParent;
-  var parentCodeElem = parentPre.querySelector("code");
-  var startValue = parentCodeElem.textContent;
+  var codeElement = event.target;
+  // It's likely that caret will be placed inside nested element that belongs to Prism
+  // We require element that contains whole example: <code class="language-css"></code>
+  while (!codeElement.classList.contains("language-css")) {
+    codeElement = codeElement.offsetParent;
+  }
 
-  event.preventDefault();
-  event.stopPropagation();
-
-  parentCodeElem.innerText = startValue + "\n" + clipboardText;
-
-  Prism.highlightElement(parentCodeElem);
+  // Adding syntax colors, after pasting process was completed natively
+  setTimeout(() => {
+    Prism.highlightElement(codeElement);
+  }, 0);
 }
 
 function handleChoiceEvent() {


### PR DESCRIPTION
This PR fixes two issues with pasting code into CSS examples(like [matrix](https://interactive-examples.mdn.mozilla.net/pages/css/function-matrix.html)):
- When caret is placed inside highlighted syntax, error is thrown(`Uncaught TypeError: Cannot read properties of null (reading 'textContent')`)
- When user selects text that he wishes to replace, that selection is ignored and new content is always added at the end.

Now editor will use native copy-paste mechanism of the contenteditable elements, we just use `Prism.highlightElement(codeElement);` afterwards.

There is still one issue regarding this feature. Prism always places caret at the very beginning of highlighted content, which is unexpected to the user. Maybe this can be resolved by using newer version of the library.

@caugner Could you review it please?