### PR TITLE
chore: update publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish-release:
     uses: mdn/workflows/.github/workflows/publish-release.yml@main
+    with:
+      target-repo: "mdn/bob"
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
Add required `target-repo` input.
Update required as a result of mdn/workflows#55