### PR TITLE
Fix horizontal scrollbar

### DIFF
--- a/editor/css/editable-css.css
+++ b/editor/css/editable-css.css
@@ -119,7 +119,7 @@
   outline-offset: 2px;
   border-right: 0;
   padding: 0;
-  right: -1.5em;
+  right: -1em;
 }
 .live .example-choice .example-choice-button:focus {
   opacity: 1;


### PR DESCRIPTION
This PR removes horizontal scrollbar which pops up unnecessarily on devices with small screen:
![image](https://user-images.githubusercontent.com/100634371/179287749-649a04a7-73ae-44e2-90aa-22a4ebf72904.png)

It happens because of "Choose example 1" texts ment for screen readers, being placed outside of the viewport. I have changed "right: 1.5em" to "right: 1em" which removes the scrollbar and still places button outside of clickabe area:
![image](https://user-images.githubusercontent.com/100634371/179288361-72bed8ee-d109-41c7-9e97-a0bb1527535d.png)

![image](https://user-images.githubusercontent.com/100634371/179288181-ee45137b-3150-4e3c-8339-5ac9e58012be.png)

