### PR TITLE
ci(dependabot): enable for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
Enables Dependabot for GitHub Actions.