### PR TITLE
ci(codeql): remove on:push

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]


### PR DESCRIPTION
Resolves the following error:

```
Error: Workflows triggered by Dependabot on the "push" event run
with read-only access. Uploading Code Scanning results requires
write access. To use Code Scanning with Dependabot, please ensure
you are using the "pull_request" event for this workflow and avoid
triggering on the "push" event for Dependabot branches. (...)
```