### PR TITLE
Fix mask-clip live example

### DIFF
--- a/live-examples/css-examples/masking/mask-clip.css
+++ b/live-examples/css-examples/masking/mask-clip.css
@@ -9,6 +9,6 @@
   margin: 40px;
   border: 20px solid #8ca0ff;
   padding: 20px;
-  mask-image: url("/media/examples/mdn.svg");
+  mask-image: url("/media/mdn.svg");
   mask-size: 100% 100%;
 }


### PR DESCRIPTION
This PR fixes the link to the SVG used for the mask clip example.
