### PR TITLE
Bump minimum Node.js to v16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
       - name: Install dependencies
         run: |
           npm install

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mdn-bob": "./lib/mdn-bob.js"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": "^16.0.0 || >=18.0.0"
   },
   "main": "./lib/mdn-bob.js",
   "bundlesize": [


### PR DESCRIPTION
This PR drops support for Node.js v12 through v15, bumping the minimum required version to v16.  Additionally, this sets the test workflow to use v16.  This synchronizes Node.js requirements with other MDN projects.

This will unblock #880 and #869.
