### PR TITLE
fixup! build: minimize css with css-minimizer-webpack-plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,10 +66,7 @@ export default {
     },
   },
   optimization: {
-    minimizer: [
-      `...`,
-      new CssMinimizerPlugin(),
-    ],
+    minimizer: [`...`, new CssMinimizerPlugin()],
     splitChunks: {
       chunks: "async",
     },


### PR DESCRIPTION
This PR fixes the formatting in the Webpack config from #889.
