### PR TITLE
fix perf script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   "main": "./lib/mdn-bob.js",
   "bundlesize": [
     {
-      "path": "./docs/css/codemirror-*.css",
+      "path": "./docs/css/codemirror.css",
       "maxSize": "3 kB"
     },
     {
-      "path": "./docs/css/css-examples-libs-*.css",
+      "path": "./docs/css/css-examples-libs.css",
       "maxSize": "4 kB"
     },
     {
@@ -42,11 +42,11 @@
       "maxSize": "33 kB"
     },
     {
-      "path": "./docs/js/codemirror-*.js",
+      "path": "./docs/js/codemirror.js",
       "maxSize": "75 kB"
     },
     {
-      "path": "./docs/js/css-examples-libs-*.js",
+      "path": "./docs/js/css-examples-libs.js",
       "maxSize": "8 kB"
     },
     {


### PR DESCRIPTION
This PR fixes script "perf" used for testing output file sizes. Currently most of the tests fail:
![image](https://user-images.githubusercontent.com/100634371/193470740-1347b571-bb94-4fc1-b4f8-ed00065609f6.png)
