### PR TITLE
Run Webpack within mdn-bob script

### DIFF
--- a/lib/mdn-bob.js
+++ b/lib/mdn-bob.js
@@ -1,9 +1,35 @@
 #!/usr/bin/env node
 
 import fse from "fs-extra";
+import webpack from "webpack";
+
+import webpackConfig from "../webpack.config.js";
 import getConfig from "./config.js";
 import * as pageBuilder from "./pageBuilder.js";
 import * as utils from "./utils.js";
+
+function doWebpack() {
+  return new Promise((resolve, reject) => {
+    webpack(webpackConfig, (err, stats) => {
+      const statsJson = stats.toJson();
+
+      if (err || stats.hasErrors()) {
+        if (err) {
+          throw err;
+        }
+        reject(statsJson.errors);
+      }
+
+      if (stats.hasWarnings()) {
+        for (const warn of statsJson.warnings) {
+          console.warn("Webpack Warning: " + warn.message);
+        }
+      }
+
+      resolve();
+    });
+  });
+}
 
 /**
  * Initialization of the module. Calls the follow on functions to generate the pages.
@@ -18,6 +44,9 @@ async function init() {
 
     console.info("MDN-BOB: Copying static assets....");
     utils.copyStaticAssets();
+
+    console.info("MDN-BOB: Running Webpack...");
+    await doWebpack();
 
     console.info("MDN-BOB: Building pages....");
     console.log(await pageBuilder.buildPages());

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     }
   ],
   "scripts": {
-    "build": "node ./lib/mdn-bob.js && webpack",
+    "build": "node ./lib/mdn-bob.js",
     "start": "npm-run-all build start-server",
     "start-server": "http-server -p 4444 ./docs",
     "format": "prettier --ignore-unknown --check \"*\"",


### PR DESCRIPTION
This PR embeds the Webpack script run into `./lib/mdn-bob.js` to retain compatibility with the existing instructions for testing mdn-bob locally in interactive-examples.  This resolves #904.
