### PR TITLE
Fix output refresh on init

### DIFF
--- a/editor/js/editor.js
+++ b/editor/js/editor.js
@@ -227,5 +227,5 @@ import "../css/tabbed-editor.css";
   tabby.registerEventListeners();
   mceEvents.register();
 
-  document.addEventListener("WebComponentsReady", () => refreshOutput());
+  refreshOutput();
 })();


### PR DESCRIPTION
This PR is a follow-up to #918 that fixes a statement that relied on the old loading method for web assembly.  Rather than wait for an event we no longer need to listen to, we instead immediately refresh the content to initially load it.
