### PR TITLE
Remove `%example-css-src%` when no path to CSS

### DIFF
--- a/lib/tabbedPageBuilder.js
+++ b/lib/tabbedPageBuilder.js
@@ -38,14 +38,14 @@ function addHTML(currentPage, tmpl) {
  * @returns the processed template string
  */
 function addJS(currentPage, tmpl) {
-  if (currentPage.jsExampleSrc) {
-    return tmpl.replace(
+  tmpl = tmpl.replace(
       "%example-js-src%",
-      fse.readFileSync(currentPage.jsExampleSrc, "utf8")
-    );
-  } else {
-    return tmpl.replace("%example-js-src%", "");
-  }
+      currentPage.jsExampleSrc
+          ? fse.readFileSync(currentPage.jsExampleSrc, "utf8")
+          : ""
+  );
+
+  return tmpl;
 }
 
 /**

--- a/lib/tabbedPageBuilder.js
+++ b/lib/tabbedPageBuilder.js
@@ -9,14 +9,12 @@ import * as processor from "./processor.js";
  * @returns the processed template string
  */
 function addCSS(currentPage, tmpl) {
-  if (currentPage.cssExampleSrc) {
-    return tmpl.replace(
-      "%example-css-src%",
-      fse.readFileSync(currentPage.cssExampleSrc, "utf8")
-    );
-  } else {
-    return tmpl.replace("%example-css-src%", "");
-  }
+  return tmpl.replace(
+    "%example-css-src%",
+    currentPage.cssExampleSrc
+      ? fse.readFileSync(currentPage.cssExampleSrc, "utf8")
+      : ""
+  );
 }
 
 /**
@@ -39,10 +37,10 @@ function addHTML(currentPage, tmpl) {
  */
 function addJS(currentPage, tmpl) {
   tmpl = tmpl.replace(
-      "%example-js-src%",
-      currentPage.jsExampleSrc
-          ? fse.readFileSync(currentPage.jsExampleSrc, "utf8")
-          : ""
+    "%example-js-src%",
+    currentPage.jsExampleSrc
+      ? fse.readFileSync(currentPage.jsExampleSrc, "utf8")
+      : ""
   );
 
   return tmpl;

--- a/lib/tabbedPageBuilder.js
+++ b/lib/tabbedPageBuilder.js
@@ -10,15 +10,13 @@ import * as processor from "./processor.js";
  */
 function addCSS(currentPage, tmpl) {
   if (currentPage.cssExampleSrc) {
-    tmpl = tmpl.replace(
+    return tmpl.replace(
       "%example-css-src%",
       fse.readFileSync(currentPage.cssExampleSrc, "utf8")
     );
   } else {
-    tmpl.replace("%example-css-src%", "");
+    return tmpl.replace("%example-css-src%", "");
   }
-
-  return tmpl;
 }
 
 /**
@@ -41,15 +39,13 @@ function addHTML(currentPage, tmpl) {
  */
 function addJS(currentPage, tmpl) {
   if (currentPage.jsExampleSrc) {
-    tmpl = tmpl.replace(
+    return tmpl.replace(
       "%example-js-src%",
       fse.readFileSync(currentPage.jsExampleSrc, "utf8")
     );
   } else {
-    tmpl = tmpl.replace("%example-js-src%", "");
+    return tmpl.replace("%example-js-src%", "");
   }
-
-  return tmpl;
 }
 
 /**


### PR DESCRIPTION
I have noticed that `addCSS` function doesn't remove `%example-css-src%` when `cssExampleSrc` is missing. I don't think it affects any live example, but if `cssExampleSrc` would be missing in tabbed example, such text would be shown. I replaced `tmpl = ` to `return` in `addCSS` & `addJS`, because it seems to me a better choice than reassigning function argument.