### PR TITLE
Apply border-radius to JS frame

### DIFF
--- a/editor/css/editor-libs/common.css
+++ b/editor/css/editor-libs/common.css
@@ -467,6 +467,7 @@ body {
 .output-header.full-border {
   border: 1px solid var(--border-primary);
   border-width: 1px 1px 0 1px;
+  border-radius: var(--button-radius) var(--button-radius) 0 0;
 }
 
 .output-heading {


### PR DESCRIPTION
This PR fixes border-radius on the top of JS frame.
**Before:**
![image](https://user-images.githubusercontent.com/100634371/204140657-98f611c4-3462-43c1-9857-7a486f0248bc.png)

**After:**
![image](https://user-images.githubusercontent.com/100634371/204140662-49c63dd6-2119-45f2-9541-da5d00cc78d4.png)
