### PR TITLE
Fix height of CSS example buttons

### DIFF
--- a/editor/css/editable-css.css
+++ b/editor/css/editable-css.css
@@ -86,6 +86,7 @@
   padding-right: 1rem;
   background: none;
   border: none;
+  font-size: .875rem;
 }
 
 .live .example-choice .ͼ1.cm-editor.cm-focused {

--- a/editor/css/editable-css.css
+++ b/editor/css/editable-css.css
@@ -86,7 +86,7 @@
   padding-right: 1rem;
   background: none;
   border: none;
-  font-size: .875rem;
+  font-size: 0.875rem;
 }
 
 .live .example-choice .ͼ1.cm-editor.cm-focused {


### PR DESCRIPTION
Currently pretty much every CSS example has a scrollbar, because of invalid height of CodeMirror editor. For example this is `accent-color` in old editor:
![image](https://user-images.githubusercontent.com/100634371/204150074-8893a8e4-077f-4ecf-9b69-ba9265e51699.png)
This is new editor:
![image](https://user-images.githubusercontent.com/100634371/204150236-15943277-7619-4a4c-b718-d0516278d27d.png)

I have fixed it by changing font-size to 0.875rem, which was applied internally by old editor:
![image](https://user-images.githubusercontent.com/100634371/204150507-5c760079-70c1-4a13-8a64-ce9cc0648d08.png)
