### PR TITLE
Fix height of tabbed examples

### DIFF
--- a/editor/css/tabbed-editor.css
+++ b/editor/css/tabbed-editor.css
@@ -6,15 +6,15 @@
 
 /* sizing utility classes */
 .tabbed-shorter .cm-editor {
-  height: 252px;
+  height: 264px;
 }
 
 .tabbed-standard .cm-editor {
-  height: 322px;
+  height: 334px;
 }
 
 .tabbed-taller .cm-editor {
-  height: 532px;
+  height: 544px;
 }
 
 .tabbed-taller .cm-editor,


### PR DESCRIPTION
This PR removes gap between line numbers and tabbed editor border, intruduced by [#773](https://github.com/mdn/bob/pull/773).
Before:
![image](https://user-images.githubusercontent.com/100634371/204152352-0e95dbdc-7c60-4b91-9843-6b09923efabc.png)

After:
![image](https://user-images.githubusercontent.com/100634371/204152288-be885100-58b6-481e-9f84-de5018b72e30.png)
