### PR TITLE
Selected tab is now always blue

### DIFF
--- a/editor/css/editor-libs/tabby.css
+++ b/editor/css/editor-libs/tabby.css
@@ -22,7 +22,7 @@ button[role="tab"]:focus {
   color: var(--text-primary);
 }
 
-button[aria-selected="true"] {
+button[role="tab"][aria-selected="true"] {
   color: var(--accent-primary);
   border-bottom-color: var(--accent-primary);
   background-color: var(--background-tertiary);


### PR DESCRIPTION
This PR is meant to fix way of applying blue color on tabs in tabbed/HTML examples.
Before:

https://user-images.githubusercontent.com/100634371/204152944-6d6c5595-0b80-4389-b092-4260f711865e.mp4

After:

https://user-images.githubusercontent.com/100634371/204152949-d26d6e14-9a55-4666-8ab0-383d0d8ec120.mp4

