### PR TITLE
Fast build command without WebPack

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -12,7 +12,19 @@ function getConfig() {
     sync: true,
   });
 
-  return cosmiConfig.load(configFile).config;
+  const config = cosmiConfig.load(configFile).config;
+  const progressArguments = getProgressArguments();
+  return {
+    ...config,
+    ...progressArguments,
+  };
+}
+
+function getProgressArguments() {
+  const argv = process.argv;
+  return {
+    doWebPack: !argv.includes("--skip-webpack"),
+  };
 }
 
 export default getConfig;

--- a/lib/mdn-bob.js
+++ b/lib/mdn-bob.js
@@ -8,6 +8,33 @@ import getConfig from "./config.js";
 import * as pageBuilder from "./pageBuilder.js";
 import * as utils from "./utils.js";
 
+/**
+ * Making sure base output directory is created and empty
+ *
+ * In case Web Pack process is skipped, its output files are not deleted
+ */
+function cleanBaseDir(config) {
+  if (config.doWebPack) {
+    fse.emptyDirSync(config.baseDir);
+  } else {
+    fse.ensureDirSync(config.baseDir);
+
+    const baseFileNames = fse.readdirSync(config.baseDir);
+    const baseFilePaths = baseFileNames.map((n) => config.baseDir + n);
+    const notWebPackPaths = baseFilePaths.filter(
+      (p) => !pathCreatedByWebPack(config, p)
+    );
+    notWebPackPaths.forEach((filePath) => fse.removeSync(filePath));
+  }
+}
+
+function pathCreatedByWebPack(config, path) {
+  return (
+    utils.isSamePath(config.destCssDir, path) ||
+    utils.isSamePath(config.destJsDir, path)
+  );
+}
+
 function doWebpack() {
   return new Promise((resolve, reject) => {
     webpack(webpackConfig, (err, stats) => {
@@ -39,14 +66,19 @@ async function init() {
     const config = getConfig();
 
     console.info(`MDN-BOB: Cleaning or creating ${config.baseDir}....`);
-    // empty or create `config.baseDir`
-    await fse.emptyDir(config.baseDir);
+    cleanBaseDir(config);
 
     console.info("MDN-BOB: Copying static assets....");
     utils.copyStaticAssets();
 
-    console.info("MDN-BOB: Running Webpack...");
-    await doWebpack();
+    if (config.doWebPack) {
+      console.info("MDN-BOB: Running Webpack...");
+      await doWebpack();
+    } else {
+      console.warn(
+        "MDN-BOB: Skipped compilation of base JS & CSS shared by all examples"
+      );
+    }
 
     console.info("MDN-BOB: Building pages....");
     console.log(await pageBuilder.buildPages());

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,3 +35,19 @@ export function copyStaticAssets() {
   // copy fonts
   copyDirectory(config.examplesFontsRoot, config.fontsMediaDest);
 }
+
+/**
+ * Compares both arguments after trimming and removing end slash
+ */
+export function isSamePath(p1, p2) {
+  const removeEndSlash = (path) => {
+    if (path.endsWith("/")) {
+      return path.substring(0, path.length - 1);
+    }
+    return path;
+  };
+
+  const normalize = (path) => removeEndSlash(path.trim());
+
+  return normalize(p1) == normalize(p2);
+}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   ],
   "scripts": {
     "build": "node ./lib/mdn-bob.js",
+    "build-pages": "node ./lib/mdn-bob.js --skip-webpack",
     "start": "npm-run-all build start-server",
     "start-server": "http-server -p 4444 ./docs",
     "format": "prettier --ignore-unknown --check \"**/*\"",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   ],
   "scripts": {
     "build": "node ./lib/mdn-bob.js",
-    "build-pages": "node ./lib/mdn-bob.js --skip-webpack",
+    "build:pages": "node ./lib/mdn-bob.js --skip-webpack",
     "start": "npm-run-all build start-server",
     "start-server": "http-server -p 4444 ./docs",
     "format": "prettier --ignore-unknown --check \"**/*\"",


### PR DESCRIPTION
This PR adds `build-pages` command, which skips webpack process and just copies static assets and builds pages.
Running this command takes 2 seconds on all current interactive examples, while using `build` takes 25 seconds. It will be huge time saving while adding new examples.