### PR TITLE
refactor!: Change mdn-bob to @mdn/bob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mdn/bob",
-  "version": "3.0.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mdn/bob",
-      "version": "3.0.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mdn-bob",
-  "version": "2.2.1",
+  "name": "@mdn/bob",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "mdn-bob",
-      "version": "2.2.1",
+      "name": "@mdn/bob",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdn/bob",
-  "version": "3.0.0",
+  "version": "2.2.1",
   "description": "Builder of Bits aka The MDN Web Docs interactive examples, example builder",
   "author": "Mozilla",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mdn-bob",
-  "version": "2.2.1",
+  "name": "@mdn/bob",
+  "version": "3.0.0",
   "description": "Builder of Bits aka The MDN Web Docs interactive examples, example builder",
   "author": "Mozilla",
   "license": "MIT",


### PR DESCRIPTION
This PR changes the package name from `mdn-bob` to `@mdn/bob`, which fixes #515.

This is a part of work for https://github.com/mdn/bob/issues/881.
