### PR TITLE
Include `mathml` examples in height-data

### DIFF
--- a/lib/heightBuilder.js
+++ b/lib/heightBuilder.js
@@ -46,6 +46,7 @@ function getEditorName(page) {
       return "css";
     case "tabbed":
     case "webapi-tabbed":
+    case "mathml":
       switch (page.height) {
         case "tabbed-taller":
         case "tabbed-standard":


### PR DESCRIPTION
This is a simple fix of `mathml` examples failing to build because they were not designated to any editor in the heightBuilder.

@queengooborg 