### PR TITLE
Set "cache" input for publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,6 +10,7 @@ jobs:
     uses: mdn/workflows/.github/workflows/publish-release.yml@main
     with:
       target-repo: "mdn/bob"
+      cache: "npm"
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
This PR sets the `cache` input to NPM for the `publish-release` workflow.  Depends on https://github.com/mdn/workflows/pull/116.