### PR TITLE
docs(changelog): Add unformatted commits to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,53 @@
 # Changelog
 
-## [3.0.0](https://github.com/mdn/bob/compare/v2.2.1...v3.0.0) (2023-02-09)
-
+## [3.0.0](https://github.com/mdn/bob/compare/v2.2.0...v3.0.0) (2023-02-09)
 
 ### ⚠ BREAKING CHANGES
 
-* change mdn-bob to @mdn/bob ([#1073](https://github.com/mdn/bob/issues/1073))
+- change mdn-bob to @mdn/bob ([#1073](https://github.com/mdn/bob/issues/1073))
+- Use ES6 features ([#918](https://github.com/mdn/bob/issues/918))
+- Bump minimum Node.js to v16 ([#882](https://github.com/mdn/bob/issues/882))
+- Convert to ESM ([#880](https://github.com/mdn/bob/issues/880))
 
 ### Code Refactoring
 
-* change mdn-bob to @mdn/bob ([#1073](https://github.com/mdn/bob/issues/1073)) ([67b4f33](https://github.com/mdn/bob/commit/67b4f330e7b7a1581df9608ce0ecdbde4830fdd4))
+- change mdn-bob to @mdn/bob ([#1073](https://github.com/mdn/bob/issues/1073)) ([67b4f33](https://github.com/mdn/bob/commit/67b4f330e7b7a1581df9608ce0ecdbde4830fdd4))
+- Use ES6 features ([#918](https://github.com/mdn/bob/issues/918)) ([78e022e](https://github.com/mdn/bob/commit/78e022e5d5f7a96ec4cce48d496b6711ea0d6f20))
+- Replace Prismjs and manual code editing system with CodeMirror ([#888](https://github.com/mdn/bob/issues/888)) ([839c592](https://github.com/mdn/bob/commit/839c592e6e4e66c8f305dd914de2c1aeaf4f763b))
+- Update CodeMirror to v6 & drop Browserify ([#907](https://github.com/mdn/bob/issues/907)) ([059aa9a](https://github.com/mdn/bob/commit/059aa9aef38d82094b4c3321f47233dc6c10ad86))
+- Tabbed examples use IFrame instead of Shadow DOM ([#903](https://github.com/mdn/bob/issues/903)) ([61478c7](https://github.com/mdn/bob/commit/61478c7fd07cb7d46b4887827d86f53d41817aae))
+- Convert to ESM ([#880](https://github.com/mdn/bob/issues/880)) ([5fbaec9](https://github.com/mdn/bob/commit/5fbaec9ea8c8d192f66c1d8ee315d9e802702110))
+- Bump minimum Node.js to v16 ([#882](https://github.com/mdn/bob/issues/882)) ([14244c5](https://github.com/mdn/bob/commit/14244c520b779c0ec0cfe818fdfc4833da6f5030))
+- Migrate to Webpack ([#867](https://github.com/mdn/bob/issues/867)) ([f3dd3c3](https://github.com/mdn/bob/commit/f3dd3c389250c35d4cd54dcc99e77c0b40193d46)), ([#871](https://github.com/mdn/bob/issues/871)) ([d150405](https://github.com/mdn/bob/commit/d1504059234db26c9e34be538fcd2a195c3c0a89)), ([#925](https://github.com/mdn/bob/issues/925)) ([6e800ed](https://github.com/mdn/bob/commit/6e800ed8e636e4ca6d6fe1d4aeb8d4fb6bd0ff59)) and ([#907](https://github.com/mdn/bob/issues/907)) ([059aa9a](https://github.com/mdn/bob/commit/059aa9aef38d82094b4c3321f47233dc6c10ad86))
 
-### [2.2.1](https://github.com/mdn/bob/compare/v2.2.0...v2.2.1) (2022-05-24)
+### Features
+
+- Add `height-data.json` ([#839](https://github.com/mdn/bob/issues/839)) ([b4f2d09](https://github.com/mdn/bob/commit/b4f2d09a4e53a1ba16f13f5348bdecdc6f598031)) and ([#1075](https://github.com/mdn/bob/issues/1075)) ([68f955d](https://github.com/mdn/bob/commit/68f955d32f1d34a599d053db7264259bf8c966ac))
+- Add support for MathML ([#1063](https://github.com/mdn/bob/issues/1063)) ([ac213d2](https://github.com/mdn/bob/commit/ac213d223b8c48fff1f6ff0bdbb38c8dbe6a6542))
+- Add `build:pages` to fast build pages without Webpack ([#1008](https://github.com/mdn/bob/issues/1008)) ([e421916](https://github.com/mdn/bob/commit/e421916b47a2a1c6ea0b010db65752006f01db0d))
+- Allow hidden CSS src in tabbed examples ([#989](https://github.com/mdn/bob/issues/989)) ([50a2473](https://github.com/mdn/bob/commit/50a2473e6c72aabaa896fc9ea81819ead37d741e))
+- Apply border-radius to JS frame ([#1003](https://github.com/mdn/bob/issues/1003)) ([7ec7f6c](https://github.com/mdn/bob/commit/7ec7f6cafbcc2f02c92749f0523eb1166d517dd0))
+- Add hover background to tabs ([#1007](https://github.com/mdn/bob/issues/1007)) ([ee9c73](https://github.com/mdn/bob/commit/ee9c73ea1be2c2ccca1045b0896e803719199fcb))
+- Enable all standardized wasm features ([#1046](https://github.com/mdn/bob/issues/1046)) ([639aabc](https://github.com/mdn/bob/commit/639aabceb018a44fe10e70808b4c386c433c019c))
+- Add UI on unsupported property values ([#763](https://github.com/mdn/bob/issues/763)) ([85c0529](https://github.com/mdn/bob/commit/85c05294c2679662141fcfc06683f204480b74b0))
+- Add hover background color to editor tabs (with transitions) ([#865](https://github.com/mdn/bob/issues/865)) ([ae46756](https://github.com/mdn/bob/commit/ae46756f7566a839797cec1f77567786b493efbd))
+- Optional tabs ([#812](https://github.com/mdn/bob/issues/812)) ([00bc9b0](https://github.com/mdn/bob/commit/00bc9b0d90f1fa887d0ad3f90d3ebe64bcfbe77a))
+- Enable reference-types in wasm examples ([#842](https://github.com/mdn/bob/issues/842)) ([9311bdf](https://github.com/mdn/bob/commit/9311bdf5965c38a11c29bd09975396d562adc0f1))
+- Enable exceptions flag for wasm ([#782](https://github.com/mdn/bob/issues/782)) ([59da034](https://github.com/mdn/bob/commit/59da034e228b3d60c25594163b52d9243cbe9e65))
 
 ### Bug Fixes
 
+- Catch localStorage usage exception ([#1038](https://github.com/mdn/bob/issues/1038)) ([bf461ca](https://github.com/mdn/bob/commit/bf461ca73728074da24b04b2e9fe91cc44ba65bd))
+- Fix height of tabbed examples ([#1006](https://github.com/mdn/bob/issues/1006)) ([9d5905d](https://github.com/mdn/bob/commit/9d5905dc9ef8f22bd428486657982d01a866c330))
+- Fix height of CSS example buttons ([#1005](https://github.com/mdn/bob/issues/1005)) ([00bba90](https://github.com/mdn/bob/commit/00bba90ea563e30b9064494a66772b2f05039635))
+- Fix double border in WAT examples ([#1004](https://github.com/mdn/bob/issues/1004)) ([056bbfe](https://github.com/mdn/bob/commit/056bbfec40b18406e48096c0940a646eef59869c))
+- Remove `%example-css-src%` when no path to CSS ([#988](https://github.com/mdn/bob/issues/988)) ([4abcd2a](https://github.com/mdn/bob/commit/4abcd2a6983324b0518f0477c56bb140b10aebe2))
+- Fix output refresh on init ([#960](https://github.com/mdn/bob/issues/960)) ([b0996af](https://github.com/mdn/bob/commit/b0996af547984a301b57443c03f0d6791825dcd0))
+- Correct behavior for URL fragment links ([#914](https://github.com/mdn/bob/issues/914)) ([6d82045](https://github.com/mdn/bob/commit/6d82045e1eb276398fce271ff9f97b534290ed1f))
+- Improve color contrast ([#908](https://github.com/mdn/bob/issues/908)) ([b9f5252](https://github.com/mdn/bob/commit/b9f52521e34b4b8ed98507add6dc62e08cbfc89c))
+- Minimum top margin in tabbed examples ([#820](https://github.com/mdn/bob/issues/820)) ([870de64](https://github.com/mdn/bob/commit/870de64079f15c1664c5b00c72e4b5946ece79f3))
+- Fix mask-clip live example ([#873](https://github.com/mdn/bob/issues/873)) ([29ee5f2](https://github.com/mdn/bob/commit/29ee5f2fe9662d96cc816baaaf52b2ecba8cb7e7))
+- Fix horizontal scrollbar ([#837](https://github.com/mdn/bob/issues/837)) ([54c2d4c](https://github.com/mdn/bob/commit/54c2d4c51f0b92259c02bd330b761990fe9d4b5d))
 - **editor:** handle paste events properly ([#776](https://github.com/mdn/bob/issues/776)) ([5beccb7](https://github.com/mdn/bob/commit/5beccb7f45fe86280ef520cedb8cb3a4e55e97c3))
 - **editor:** replace margin-top on tab-list by border-top on tab ([#773](https://github.com/mdn/bob/issues/773)) ([d34d8a0](https://github.com/mdn/bob/commit/d34d8a06810d15f510cf275822b8b20cb5a9c05d))
 - **editor:** warn if JavaScript disabled or unsupported feature ([#759](https://github.com/mdn/bob/issues/759)) ([08fe714](https://github.com/mdn/bob/commit/08fe714908ad23dc3557d7778c03ff5c07c51692))


### PR DESCRIPTION
This change adds all of the commits that have not been formatted with `release-please`-friendly commit messages to document all new features, bug fixes and breaking changes to the changelog.  Additionally, this removes mention of v2.2.1 as it was never published on NPM.
