### PR TITLE
fix(deps): Replace uglify-es with uglify-js

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,6 +1,6 @@
 import CleanCSS from "clean-css";
 import fse from "fs-extra";
-import uglify from "uglify-es";
+import uglify from "uglify-js";
 import getConfig from "./config.js";
 
 const config = getConfig();

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "cosmiconfig": "8.0.0",
         "fs-extra": "11.1.0",
         "glob": "8.1.0",
-        "uglify-es": "3.3.9",
+        "uglify-js": "^3.17.4",
         "wabt": "^1.0.29",
         "webpack": "5.75.0"
       },
@@ -10381,26 +10381,16 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-      "deprecated": "support for ECMAScript is superseded by `uglify-js` as of v3.13.0",
-      "dependencies": {
-        "commander": "~2.13.0",
-        "source-map": "~0.6.1"
-      },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "bin": {
         "uglifyjs": "bin/uglifyjs"
       },
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/uglify-es/node_modules/commander": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-      "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -18799,21 +18789,10 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
-    "uglify-es": {
-      "version": "3.3.9",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-      "requires": {
-        "commander": "~2.13.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
-        }
-      }
+    "uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "cosmiconfig": "8.0.0",
     "fs-extra": "11.1.0",
     "glob": "8.1.0",
-    "uglify-es": "3.3.9",
+    "uglify-js": "^3.17.4",
     "wabt": "^1.0.29",
     "webpack": "5.75.0"
   },


### PR DESCRIPTION
This PR replaces the [now-deprecated `uglify-es`](https://www.npmjs.com/package/uglify-es) with `uglify-js`.
