### PR TITLE
fix: Add `CHANGELOG.md` to `.prettierignore`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ build
 coverage
 docs
 node_modules
+# This can be removed after https://github.com/googleapis/release-please/issues/1802 is fixed
+CHANGELOG.md


### PR DESCRIPTION
Adding `CHANGELOG.md` to `.prettierignore`, because prettier tests are failing after the following addition, auto-generated by `release-please`:
```
* **deps:** Move build dependencies to non-dev dependencies ([#1107](https://github.com/mdn/bob/issues/1107)) ([0b03a8f](https://github.com/mdn/bob/commit/0b03a8fd5f4e9073c5bace25bbde8ad3ea2b75c3))
* **deps:** Replace uglify-es with uglify-js ([#1114](https://github.com/mdn/bob/issues/1114)) ([647f098](https://github.com/mdn/bob/commit/647f098764cf4dfc15176ac35007f97aec489793))
* Fix file references ([#1116](https://github.com/mdn/bob/issues/1116)) ([38bb023](https://github.com/mdn/bob/commit/38bb023903e047196f06f6e9062398cb66f5f2e5))
* **jest:** specify host ([#1108](https://github.com/mdn/bob/issues/1108)) ([4660078](https://github.com/mdn/bob/commit/46600788468e90c7171611e29f9ba604da919dda))
```
Related to [#1802](https://github.com/googleapis/release-please/issues/1802)