### PR TITLE
fix(build): output in cwd, not import.meta.url

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ export default {
     ),
   },
   output: {
-    path: fileURLToPath(new URL("docs", import.meta.url)),
+    path: path.join(process.cwd(), "docs"),
     filename: "js/[name].js",
   },
   module: {


### PR DESCRIPTION
In bob, cwd and import.meta.url are identical, but in the context of interactive-examples, import.meta.url points inside node_modules.