### PR TITLE
fix(style): Remove scrollbars from few CSS examples

### DIFF
--- a/editor/css/editable-css.css
+++ b/editor/css/editable-css.css
@@ -274,6 +274,7 @@
 
   .live .example-choice pre {
     flex-grow: 1;
+    margin: 0;
   }
 
   .output section {


### PR DESCRIPTION
Removes unnecessary scrollbar from CSS examples in which "choice" buttons have quite a long content.

**Before:**
![image](https://user-images.githubusercontent.com/100634371/221253160-eedc4734-fd41-4032-8ab7-21170a890c69.png)

**After:**
![image](https://user-images.githubusercontent.com/100634371/221253644-acf73614-6368-4202-82b9-85228fbded3c.png)

I have checked about 50 examples and this seems to work fine.

@caugner Could we release this before publishing v3?