### PR TITLE
fix(style): Use better text selection color

### DIFF
--- a/editor/css/editor-libs/codemirror-override.css
+++ b/editor/css/editor-libs/codemirror-override.css
@@ -25,6 +25,15 @@
   border-color: var(--text-primary);
 }
 
+.cm-editor .cm-line::selection,
+.cm-editor .cm-line ::selection {
+  background-color: var(--selection-backgroud-color) !important;
+}
+.cm-editor .cm-selectionBackground,
+.cm-editor.cm-focused .cm-selectionBackground {
+  background-color: initial;
+}
+
 /* Language specific rules */
 .cm-operator,
 .cm-variable {

--- a/editor/css/editor-libs/codemirror-override.css
+++ b/editor/css/editor-libs/codemirror-override.css
@@ -27,7 +27,7 @@
 
 .cm-editor .cm-line::selection,
 .cm-editor .cm-line ::selection {
-  background-color: var(--selection-backgroud-color) !important;
+  background-color: var(--selection-background-color) !important;
 }
 .cm-editor .cm-selectionBackground,
 .cm-editor.cm-focused .cm-selectionBackground {

--- a/editor/css/editor-libs/common.css
+++ b/editor/css/editor-libs/common.css
@@ -108,7 +108,7 @@
   --http-accent-background-color: #009a4630;
   --apis-accent-background-color: #9b65ff30;
   --learn-accent-background-color: #ff1f7230;
-  --selection-backgroud-color: #d3e7ff;
+  --selection-background-color: #d3e7ff;
   --plus-accent-engage: rgba(255, 42, 81, 0.7);
   --html-accent-engage: rgba(255, 42, 81, 0.7);
   --css-accent-engage: rgba(0, 133, 242, 0.7);
@@ -218,7 +218,7 @@
   --apis-accent-engage: rgba(174, 138, 255, 0.7);
   --learn-accent-engage: rgba(255, 109, 145, 0.7);
   --modal-backdrop-color: rgba(27, 27, 27, 0.7);
-  --selection-backgroud-color: #233244;
+  --selection-background-color: #233244;
   --blend-color: #00080;
   --text-primary-red: #ff97a0;
   --text-primary-green: #00d061;
@@ -319,7 +319,7 @@
     --http-accent-background-color: #009a4630;
     --apis-accent-background-color: #9b65ff30;
     --learn-accent-background-color: #ff1f7230;
-    --selection-backgroud-color: #d3e7ff;
+    --selection-background-color: #d3e7ff;
     --plus-accent-engage: rgba(255, 42, 81, 0.7);
     --html-accent-engage: rgba(255, 42, 81, 0.7);
     --css-accent-engage: rgba(0, 133, 242, 0.7);
@@ -437,7 +437,7 @@
     --text-primary-green: #00d061;
     --text-primary-blue: #8cb4ff;
     --text-primary-yellow: #c7b700;
-    --selection-backgroud-color: #233244;
+    --selection-background-color: #233244;
   }
 }
 

--- a/editor/css/editor-libs/common.css
+++ b/editor/css/editor-libs/common.css
@@ -108,6 +108,7 @@
   --http-accent-background-color: #009a4630;
   --apis-accent-background-color: #9b65ff30;
   --learn-accent-background-color: #ff1f7230;
+  --selection-backgroud-color: #d3e7ff;
   --plus-accent-engage: rgba(255, 42, 81, 0.7);
   --html-accent-engage: rgba(255, 42, 81, 0.7);
   --css-accent-engage: rgba(0, 133, 242, 0.7);
@@ -217,6 +218,7 @@
   --apis-accent-engage: rgba(174, 138, 255, 0.7);
   --learn-accent-engage: rgba(255, 109, 145, 0.7);
   --modal-backdrop-color: rgba(27, 27, 27, 0.7);
+  --selection-backgroud-color: #233244;
   --blend-color: #00080;
   --text-primary-red: #ff97a0;
   --text-primary-green: #00d061;
@@ -317,6 +319,7 @@
     --http-accent-background-color: #009a4630;
     --apis-accent-background-color: #9b65ff30;
     --learn-accent-background-color: #ff1f7230;
+    --selection-backgroud-color: #d3e7ff;
     --plus-accent-engage: rgba(255, 42, 81, 0.7);
     --html-accent-engage: rgba(255, 42, 81, 0.7);
     --css-accent-engage: rgba(0, 133, 242, 0.7);
@@ -434,6 +437,7 @@
     --text-primary-green: #00d061;
     --text-primary-blue: #8cb4ff;
     --text-primary-yellow: #c7b700;
+    --selection-backgroud-color: #233244;
   }
 }
 

--- a/editor/css/editor-libs/common.css
+++ b/editor/css/editor-libs/common.css
@@ -171,7 +171,7 @@
   --field-focus-border: #fff;
   --code-token-tag: #c1cff1;
   --code-token-punctuation: #9e9e9e;
-  --code-token-attribute-name: #ff97a0;
+  --code-token-attribute-name: #ffbb88;
   --code-token-attribute-value: #00d061;
   --code-token-comment: #9e9e9e;
   --code-token-default: #fff;
@@ -385,7 +385,7 @@
     --field-focus-border: #fff;
     --code-token-tag: #c1cff1;
     --code-token-punctuation: #9e9e9e;
-    --code-token-attribute-name: #ff97a0;
+    --code-token-attribute-name: #ffbb88;
     --code-token-attribute-value: #00d061;
     --code-token-comment: #9e9e9e;
     --code-token-default: #fff;


### PR DESCRIPTION
This PR adds more suitable text selection colors in code mirror editors.

**Before:**
![image](https://user-images.githubusercontent.com/100634371/221377757-f791e648-d235-44a0-874f-4ffc494bb408.png)
![image](https://user-images.githubusercontent.com/100634371/221377748-4b65ed1f-ec25-4874-bd6b-edf8588129ef.png)


**After:**
![image](https://user-images.githubusercontent.com/100634371/221377705-325fca3d-9c1f-4bde-b561-0fbc35f43ec1.png)
![image](https://user-images.githubusercontent.com/100634371/221377715-7809db46-298f-4a91-a5fa-7ac661bffb33.png)


[Myndex](https://github.com/Myndex) Could you please take a look, if those colors look fine?
Fixes [#2435](https://github.com/mdn/interactive-examples/issues/2435)