### PR TITLE
fix(style): Make font-family of code, match ordinary MDN examples

### DIFF
--- a/editor/css/editor-libs/codemirror-override.css
+++ b/editor/css/editor-libs/codemirror-override.css
@@ -19,6 +19,7 @@
 
 .cm-editor .cm-scroller {
   line-height: inherit;
+  font-family: var(--font-code);
 }
 
 .cm-editor .cm-cursor {

--- a/editor/css/editor-libs/common.css
+++ b/editor/css/editor-libs/common.css
@@ -2,7 +2,8 @@
   --font-fallback: BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
     "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-sans;
   --font-body: Inter, var(--font-fallback);
-  --font-code: Consolas, "Courier New", monospace;
+  --font-code: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console,
+    monospace;
   --type-body-l: 400 1rem/1.1876 var(--font-body); /* 16px/19px */
   --type-emphasis-m: 600 0.8125rem/1.23 var(--font-body); /* 13px/16px */
   --font-heading: var(--font-body);


### PR DESCRIPTION
This PR changes `font-family` of code-mirror code fragments to `Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace`. The list of fonts matches `--font-code` in [yari](https://github.com/mdn/yari/blob/main/client/src/app.scss), which is used in ordinary code examples, like this:
![image](https://user-images.githubusercontent.com/100634371/221379638-a0ca593a-392a-49b5-ac11-a091398774d3.png)

Fixes #731 