### PR TITLE
fix(style): Fix horizontal scrollbar of js editor

### DIFF
--- a/editor/css/editable-js-and-wat.css
+++ b/editor/css/editable-js-and-wat.css
@@ -119,9 +119,15 @@
     flex-direction: row;
   }
 
+  .output {
+    width: calc(
+      100% - 108px
+    ); /* 108px is 100px of a .button width + 8px of a .buttons-container padding-right */
+  }
+
   .buttons-container {
     flex-direction: column;
     width: auto;
-    padding-right: 0.5rem;
+    padding-right: 8px;
   }
 }


### PR DESCRIPTION
This PR removes a horizontal scrollbar from the JS editor when an output content is too long.

Before:
![image](https://user-images.githubusercontent.com/100634371/221640047-3a166c45-ed02-4d80-a90f-30a78ef775b4.png)

After:
![image](https://user-images.githubusercontent.com/100634371/221639856-2f4f82db-f79e-454a-8a0e-c84180ced801.png)

Fixes #272