### PR TITLE
feat(telemetry): record interactions + post to parent

### DIFF
--- a/editor/js/editor-libs/codemirror-editor.js
+++ b/editor/js/editor-libs/codemirror-editor.js
@@ -23,7 +23,7 @@ import { parser as jsParser } from "@lezer/javascript";
 import { parser as htmlParser } from "@lezer/html";
 import { parser as cssParser } from "@lezer/css";
 
-import { postActionMessage } from "./telemetry.js";
+import { recordAction } from "./telemetry.js";
 
 import "../../css/editor-libs/codemirror-override.css";
 
@@ -180,7 +180,7 @@ function mixedHTML() {
 
 function eventHandlers() {
   return EditorView.domEventHandlers({
-    input: () => postActionMessage("input", true),
+    input: () => recordAction("input", true),
   });
 }
 

--- a/editor/js/editor-libs/codemirror-editor.js
+++ b/editor/js/editor-libs/codemirror-editor.js
@@ -23,7 +23,7 @@ import { parser as jsParser } from "@lezer/javascript";
 import { parser as htmlParser } from "@lezer/html";
 import { parser as cssParser } from "@lezer/css";
 
-import { postActionMessage } from "./events.js";
+import { postActionMessage } from "./telemetry.js";
 
 import "../../css/editor-libs/codemirror-override.css";
 

--- a/editor/js/editor-libs/codemirror-editor.js
+++ b/editor/js/editor-libs/codemirror-editor.js
@@ -23,6 +23,8 @@ import { parser as jsParser } from "@lezer/javascript";
 import { parser as htmlParser } from "@lezer/html";
 import { parser as cssParser } from "@lezer/css";
 
+import { postActionMessage } from "./events.js";
+
 import "../../css/editor-libs/codemirror-override.css";
 
 /**
@@ -176,6 +178,12 @@ function mixedHTML() {
   return LRLanguage.define({ parser: mixedHTMLParser });
 }
 
+function eventHandlers() {
+  return EditorView.domEventHandlers({
+    input: () => postActionMessage("input", true),
+  });
+}
+
 /**
  * Set of basic extensions, that every editor should have.
  * This list is mostly based on [basic setup](https://github.com/codemirror/basic-setup)
@@ -201,6 +209,7 @@ const BASE_EXTENSIONS = [
     ...lintKeymap,
     TAB_KEY_MAP,
   ]),
+  eventHandlers(),
 ];
 
 /**

--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -51,10 +51,6 @@ function addPostMessageListener() {
   );
 }
 
-export function postParentMessage(type, values) {
-  parent?.postMessage({ type, url: window.location.href, ...values }, "*");
-}
-
 document.addEventListener("DOMContentLoaded", () => {
   const theme = getStorageItem("theme");
   if (theme !== null) {
@@ -88,6 +84,10 @@ function getStorageItem(key) {
 
 function sendOwnHeight() {
   postParentMessage("height", { height: document.body.scrollHeight });
+}
+
+export function postParentMessage(type, values) {
+  parent?.postMessage({ type, url: window.location.href, ...values }, "*");
 }
 
 /**

--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -86,26 +86,24 @@ function persistActionCounts(counts) {
 }
 
 const actionCounts = readActionsCounts();
+let lastAction = null;
 
 /**
  * @param {string} key
  * @param {boolean} once
  */
-export function postActionMessage(key, once = false) {
+export function postActionMessage(key, deduplicate = false) {
   actionCounts[key] = actionCounts[key] ?? 0;
 
-  let source = key;
-
-  if (!once) {
-    source += ` -> ${actionCounts[key]}`;
+  if (deduplicate && key === lastAction) {
+    return;
+  } else {
+    lastAction = key;
   }
 
+  let source = `${key} -> ${actionCounts[key]}`;
   actionCounts[key]++;
   persistActionCounts(actionCounts);
-
-  if (once && actionCounts[key] > 1) {
-    return;
-  }
 
   postParentMessage("action", { source });
 }

--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -60,7 +60,6 @@ const ACTION_COUNTS_KEY = "action-counts";
 function readActionsCounts() {
   try {
     const value = JSON.parse(localStorage.getItem(ACTION_COUNTS_KEY));
-    window.console.log("readActionsCount", value);
     if (value && value.href === window.location.href && value.counts) {
       return value.counts;
     }

--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -1,5 +1,6 @@
 import * as clippy from "./clippy.js";
 import * as cssEditorUtils from "./css-editor-utils.js";
+import { getStorageItem, storeItem } from "./utils.js";
 
 /**
  * Adds listeners for events from the CSS live examples
@@ -57,30 +58,6 @@ document.addEventListener("DOMContentLoaded", () => {
     document.querySelector("body").classList.add("theme-" + theme);
   }
 });
-
-/**
- * Adds key & value to {@link localStorage}, without throwing an exception when it is unavailable
- */
-function storeItem(key, value) {
-  try {
-    localStorage.setItem(key, value);
-  } catch (err) {
-    console.warn(`Unable to write ${key} to localStorage`, err);
-  }
-}
-
-/**
- * @returns the value of a given key from {@link localStorage}, or null when the key wasn't found.
- * It doesn't throw an exception when {@link localStorage} is unavailable
- */
-function getStorageItem(key) {
-  try {
-    return localStorage.getItem(key);
-  } catch (err) {
-    console.warn(`Unable to read ${key} from localStorage`, err);
-    return null;
-  }
-}
 
 function sendOwnHeight() {
   postParentMessage("height", { height: document.body.scrollHeight });

--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -1,5 +1,6 @@
 import * as clippy from "./clippy.js";
 import * as cssEditorUtils from "./css-editor-utils.js";
+import { initTelemetry } from "./telemetry.js";
 import { getStorageItem, storeItem } from "./utils.js";
 
 /**
@@ -123,4 +124,6 @@ export function register() {
   if (exampleChoiceList) {
     addCSSEditorEventListeners(exampleChoiceList);
   }
+
+  initTelemetry();
 }

--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -55,26 +55,49 @@ function postParentMessage(type, values) {
   parent?.postMessage({ type, url: window.location.href, ...values }, "*");
 }
 
-const actionCounts = {};
+const ACTION_COUNTS_KEY = "action-counts";
+
+function readActionsCounts() {
+  try {
+    const value = JSON.parse(localStorage.getItem(ACTION_COUNTS_KEY));
+    window.console.log("readActionsCount", value);
+    if (value && value.href === window.location.href && value.counts) {
+      return value.counts;
+    }
+  } catch (e) {
+    window.console.warn("Unable to read action counts from localStorage", e);
+  }
+
+  return {};
+}
+
+function persistActionCounts(counts) {
+  try {
+    localStorage.setItem(
+      ACTION_COUNTS_KEY,
+      JSON.stringify({
+        href: window.location.href,
+        counts,
+      })
+    );
+  } catch (e) {
+    window.console.warn("Unable to write action counts to localStorage", e);
+  }
+}
+
+const actionCounts = readActionsCounts();
+
 /**
  * @param {string} key
  * @param {boolean} once
  */
-export function postActionMessage(key, once = false) {
+export function postActionMessage(key) {
   actionCounts[key] = actionCounts[key] ?? 0;
-  let source = key;
-
-  if (once && actionCounts[key] > 0) {
-    return;
-  }
-
-  if (!once) {
-    source += ` -> ${actionCounts[key]}`;
-  }
-
-  postParentMessage("action", { source });
-
+  let source = `${key} -> ${actionCounts[key]}`;
   actionCounts[key]++;
+
+  persistActionCounts(actionCounts);
+  postParentMessage("action", { source });
 }
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -87,7 +110,7 @@ document.addEventListener("DOMContentLoaded", () => {
   window.addEventListener("click", (event) => {
     const id = event.target.id;
     if (id) {
-      postActionMessage(`click@${id}`, id === "reset");
+      postActionMessage(`click@${id}`);
     }
   });
 

--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -51,76 +51,11 @@ function addPostMessageListener() {
   );
 }
 
-function postParentMessage(type, values) {
+export function postParentMessage(type, values) {
   parent?.postMessage({ type, url: window.location.href, ...values }, "*");
 }
 
-const ACTION_COUNTS_KEY = "action-counts";
-
-function readActionsCounts() {
-  try {
-    const value = JSON.parse(localStorage.getItem(ACTION_COUNTS_KEY));
-    if (value && value.href === window.location.href && value.counts) {
-      return value.counts;
-    }
-  } catch (e) {
-    window.console.warn("Unable to read action counts from localStorage", e);
-  }
-
-  return {};
-}
-
-function persistActionCounts(counts) {
-  try {
-    localStorage.setItem(
-      ACTION_COUNTS_KEY,
-      JSON.stringify({
-        href: window.location.href,
-        counts,
-      })
-    );
-  } catch (e) {
-    window.console.warn("Unable to write action counts to localStorage", e);
-  }
-}
-
-const actionCounts = readActionsCounts();
-let lastAction = null;
-
-/**
- * @param {string} key
- * @param {boolean} once
- */
-export function postActionMessage(key, deduplicate = false) {
-  actionCounts[key] = actionCounts[key] ?? 0;
-
-  if (deduplicate && key === lastAction) {
-    return;
-  } else {
-    lastAction = key;
-  }
-
-  let source = `${key} -> ${actionCounts[key]}`;
-  actionCounts[key]++;
-  persistActionCounts(actionCounts);
-
-  postParentMessage("action", { source });
-}
-
 document.addEventListener("DOMContentLoaded", () => {
-  window.addEventListener("focus", () => postActionMessage("focus"));
-
-  window.addEventListener("copy", () => postActionMessage("copy"));
-  window.addEventListener("cut", () => postActionMessage("cut"));
-  window.addEventListener("paste", () => postActionMessage("paste"));
-
-  window.addEventListener("click", (event) => {
-    const id = event.target.id;
-    if (id) {
-      postActionMessage(`click@${id}`);
-    }
-  });
-
   const theme = getStorageItem("theme");
   if (theme !== null) {
     document.querySelector("body").classList.add("theme-" + theme);

--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -91,12 +91,22 @@ const actionCounts = readActionsCounts();
  * @param {string} key
  * @param {boolean} once
  */
-export function postActionMessage(key) {
+export function postActionMessage(key, once = false) {
   actionCounts[key] = actionCounts[key] ?? 0;
-  let source = `${key} -> ${actionCounts[key]}`;
-  actionCounts[key]++;
 
+  let source = key;
+
+  if (!once) {
+    source += ` -> ${actionCounts[key]}`;
+  }
+
+  actionCounts[key]++;
   persistActionCounts(actionCounts);
+
+  if (once && actionCounts[key] > 1) {
+    return;
+  }
+
   postParentMessage("action", { source });
 }
 

--- a/editor/js/editor-libs/telemetry.js
+++ b/editor/js/editor-libs/telemetry.js
@@ -43,7 +43,7 @@ function storeActionCounts(counts) {
  * Action counts by key.
  * Used to distinguish 1st/2nd/etc occurrences of the same event.
  */
-const actionCounts = getActionsCounts();
+let actionCounts = {};
 
 /**
  * Last observed action.
@@ -71,20 +71,25 @@ export function recordAction(key, deduplicate = false) {
   postParentMessage("action", { source });
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  // User focuses the iframe.
-  window.addEventListener("focus", () => recordAction("focus"));
+export function initTelemetry() {
+  actionCounts = getActionsCounts();
+  lastAction = null;
 
-  // User copies / cuts / paste text in the iframe.
-  window.addEventListener("copy", () => recordAction("copy"));
-  window.addEventListener("cut", () => recordAction("cut"));
-  window.addEventListener("paste", () => recordAction("paste"));
+  document.addEventListener("DOMContentLoaded", () => {
+    // User focuses the iframe.
+    window.addEventListener("focus", () => recordAction("focus"));
 
-  // User clicks on any element with an id.
-  window.addEventListener("click", (event) => {
-    const id = event.target.id;
-    if (id) {
-      recordAction(`click@${id}`);
-    }
+    // User copies / cuts / paste text in the iframe.
+    window.addEventListener("copy", () => recordAction("copy"));
+    window.addEventListener("cut", () => recordAction("cut"));
+    window.addEventListener("paste", () => recordAction("paste"));
+
+    // User clicks on any element with an id.
+    window.addEventListener("click", (event) => {
+      const id = event.target.id;
+      if (id) {
+        recordAction(`click@${id}`);
+      }
+    });
   });
-});
+}

--- a/editor/js/editor-libs/telemetry.js
+++ b/editor/js/editor-libs/telemetry.js
@@ -58,18 +58,16 @@ let lastAction = null;
  * @param {boolean} deduplicate - Should multiple actions of the same type be ignored until another action occurred?
  */
 export function recordAction(key, deduplicate = false) {
-  actionCounts[key] = actionCounts[key] ?? 0;
-
   if (deduplicate && key === lastAction) {
     return;
   } else {
     lastAction = key;
   }
 
-  const source = `${key} -> ${actionCounts[key]}`;
-  actionCounts[key]++;
+  actionCounts[key] = (actionCounts[key] ?? 0) + 1;
   storeActionCounts(actionCounts);
 
+  const source = `${key} -> ${actionCounts[key]}`;
   postParentMessage("action", { source });
 }
 

--- a/editor/js/editor-libs/telemetry.js
+++ b/editor/js/editor-libs/telemetry.js
@@ -2,6 +2,12 @@ import { postParentMessage } from "./events.js";
 
 const ACTION_COUNTS_KEY = "action-counts";
 
+/**
+ * Reads action counts from local storage.
+ * Ignores action counts that belong to another example.
+ *
+ * @returns The action counts from the previous session, if available.
+ */
 function readActionsCounts() {
   try {
     const value = JSON.parse(localStorage.getItem(ACTION_COUNTS_KEY));
@@ -15,6 +21,11 @@ function readActionsCounts() {
   return {};
 }
 
+/**
+ * Writes action counts to local storage, to persist them between reloads.
+ *
+ * @param {object} counts - The current action counts.
+ */
 function persistActionCounts(counts) {
   try {
     localStorage.setItem(
@@ -29,12 +40,23 @@ function persistActionCounts(counts) {
   }
 }
 
+/**
+ * Action counts by key.
+ * Used to distinguish 1st/2nd/etc occurrences of the same event.
+ */
 const actionCounts = readActionsCounts();
+
+/**
+ * Last observed action.
+ * Used to ignore multiple input actions until another action happened.
+ */
 let lastAction = null;
 
 /**
- * @param {string} key
- * @param {boolean} once
+ * Records an action, by counting it and forwarding it to the window parent.
+ *
+ * @param {string} key - Distinct name of the type of action.
+ * @param {boolean} deduplicate - Should multiple actions of the same type be ignored until another action occurred?
  */
 export function recordAction(key, deduplicate = false) {
   actionCounts[key] = actionCounts[key] ?? 0;
@@ -53,12 +75,15 @@ export function recordAction(key, deduplicate = false) {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
+  // User focuses the iframe.
   window.addEventListener("focus", () => recordAction("focus"));
 
+  // User copies / cuts / paste text in the iframe.
   window.addEventListener("copy", () => recordAction("copy"));
   window.addEventListener("cut", () => recordAction("cut"));
   window.addEventListener("paste", () => recordAction("paste"));
 
+  // User clicks on any element with an id.
   window.addEventListener("click", (event) => {
     const id = event.target.id;
     if (id) {

--- a/editor/js/editor-libs/telemetry.js
+++ b/editor/js/editor-libs/telemetry.js
@@ -9,7 +9,7 @@ const ACTION_COUNTS_KEY = "action-counts";
  *
  * @returns The action counts from the previous session, if available.
  */
-function readActionsCounts() {
+function getActionsCounts() {
   const json = getStorageItem(ACTION_COUNTS_KEY);
 
   if (!json) {
@@ -29,7 +29,7 @@ function readActionsCounts() {
  *
  * @param {object} counts - The current action counts.
  */
-function persistActionCounts(counts) {
+function storeActionCounts(counts) {
   storeItem(
     ACTION_COUNTS_KEY,
     JSON.stringify({
@@ -43,7 +43,7 @@ function persistActionCounts(counts) {
  * Action counts by key.
  * Used to distinguish 1st/2nd/etc occurrences of the same event.
  */
-const actionCounts = readActionsCounts();
+const actionCounts = getActionsCounts();
 
 /**
  * Last observed action.
@@ -68,7 +68,7 @@ export function recordAction(key, deduplicate = false) {
 
   let source = `${key} -> ${actionCounts[key]}`;
   actionCounts[key]++;
-  persistActionCounts(actionCounts);
+  storeActionCounts(actionCounts);
 
   postParentMessage("action", { source });
 }

--- a/editor/js/editor-libs/telemetry.js
+++ b/editor/js/editor-libs/telemetry.js
@@ -36,7 +36,7 @@ let lastAction = null;
  * @param {string} key
  * @param {boolean} once
  */
-export function postActionMessage(key, deduplicate = false) {
+export function recordAction(key, deduplicate = false) {
   actionCounts[key] = actionCounts[key] ?? 0;
 
   if (deduplicate && key === lastAction) {
@@ -53,16 +53,16 @@ export function postActionMessage(key, deduplicate = false) {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  window.addEventListener("focus", () => postActionMessage("focus"));
+  window.addEventListener("focus", () => recordAction("focus"));
 
-  window.addEventListener("copy", () => postActionMessage("copy"));
-  window.addEventListener("cut", () => postActionMessage("cut"));
-  window.addEventListener("paste", () => postActionMessage("paste"));
+  window.addEventListener("copy", () => recordAction("copy"));
+  window.addEventListener("cut", () => recordAction("cut"));
+  window.addEventListener("paste", () => recordAction("paste"));
 
   window.addEventListener("click", (event) => {
     const id = event.target.id;
     if (id) {
-      postActionMessage(`click@${id}`);
+      recordAction(`click@${id}`);
     }
   });
 });

--- a/editor/js/editor-libs/telemetry.js
+++ b/editor/js/editor-libs/telemetry.js
@@ -1,0 +1,68 @@
+import { postParentMessage } from "./events.js";
+
+const ACTION_COUNTS_KEY = "action-counts";
+
+function readActionsCounts() {
+  try {
+    const value = JSON.parse(localStorage.getItem(ACTION_COUNTS_KEY));
+    if (value && value.href === window.location.href && value.counts) {
+      return value.counts;
+    }
+  } catch (e) {
+    window.console.warn("Unable to read action counts from localStorage", e);
+  }
+
+  return {};
+}
+
+function persistActionCounts(counts) {
+  try {
+    localStorage.setItem(
+      ACTION_COUNTS_KEY,
+      JSON.stringify({
+        href: window.location.href,
+        counts,
+      })
+    );
+  } catch (e) {
+    window.console.warn("Unable to write action counts to localStorage", e);
+  }
+}
+
+const actionCounts = readActionsCounts();
+let lastAction = null;
+
+/**
+ * @param {string} key
+ * @param {boolean} once
+ */
+export function postActionMessage(key, deduplicate = false) {
+  actionCounts[key] = actionCounts[key] ?? 0;
+
+  if (deduplicate && key === lastAction) {
+    return;
+  } else {
+    lastAction = key;
+  }
+
+  let source = `${key} -> ${actionCounts[key]}`;
+  actionCounts[key]++;
+  persistActionCounts(actionCounts);
+
+  postParentMessage("action", { source });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  window.addEventListener("focus", () => postActionMessage("focus"));
+
+  window.addEventListener("copy", () => postActionMessage("copy"));
+  window.addEventListener("cut", () => postActionMessage("cut"));
+  window.addEventListener("paste", () => postActionMessage("paste"));
+
+  window.addEventListener("click", (event) => {
+    const id = event.target.id;
+    if (id) {
+      postActionMessage(`click@${id}`);
+    }
+  });
+});

--- a/editor/js/editor-libs/telemetry.js
+++ b/editor/js/editor-libs/telemetry.js
@@ -66,7 +66,7 @@ export function recordAction(key, deduplicate = false) {
     lastAction = key;
   }
 
-  let source = `${key} -> ${actionCounts[key]}`;
+  const source = `${key} -> ${actionCounts[key]}`;
   actionCounts[key]++;
   storeActionCounts(actionCounts);
 

--- a/editor/js/editor-libs/telemetry.js
+++ b/editor/js/editor-libs/telemetry.js
@@ -1,4 +1,5 @@
 import { postParentMessage } from "./events.js";
+import { getStorageItem, storeItem } from "./utils.js";
 
 const ACTION_COUNTS_KEY = "action-counts";
 
@@ -9,13 +10,15 @@ const ACTION_COUNTS_KEY = "action-counts";
  * @returns The action counts from the previous session, if available.
  */
 function readActionsCounts() {
-  try {
-    const value = JSON.parse(localStorage.getItem(ACTION_COUNTS_KEY));
-    if (value && value.href === window.location.href && value.counts) {
-      return value.counts;
-    }
-  } catch (e) {
-    window.console.warn("Unable to read action counts from localStorage", e);
+  const json = getStorageItem(ACTION_COUNTS_KEY);
+
+  if (!json) {
+    return {};
+  }
+
+  const value = JSON.parse(json);
+  if (value && value.href === window.location.href && value.counts) {
+    return value.counts;
   }
 
   return {};
@@ -27,17 +30,13 @@ function readActionsCounts() {
  * @param {object} counts - The current action counts.
  */
 function persistActionCounts(counts) {
-  try {
-    localStorage.setItem(
-      ACTION_COUNTS_KEY,
-      JSON.stringify({
-        href: window.location.href,
-        counts,
-      })
-    );
-  } catch (e) {
-    window.console.warn("Unable to write action counts to localStorage", e);
-  }
+  storeItem(
+    ACTION_COUNTS_KEY,
+    JSON.stringify({
+      href: window.location.href,
+      counts,
+    })
+  );
 }
 
 /**

--- a/editor/js/editor-libs/utils.js
+++ b/editor/js/editor-libs/utils.js
@@ -1,0 +1,23 @@
+/**
+ * Adds key & value to {@link localStorage}, without throwing an exception when it is unavailable
+ */
+export function storeItem(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch (err) {
+    console.warn(`Unable to write ${key} to localStorage`, err);
+  }
+}
+
+/**
+ * @returns the value of a given key from {@link localStorage}, or null when the key wasn't found.
+ * It doesn't throw an exception when {@link localStorage} is unavailable
+ */
+export function getStorageItem(key) {
+  try {
+    return localStorage.getItem(key);
+  } catch (err) {
+    console.warn(`Unable to read ${key} from localStorage`, err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Allows us to measure how users interact with interactive-examples.

1. [**bob**] https://github.com/mdn/bob/pull/1145
2. [yari] https://github.com/mdn/yari/pull/8337

### Problem

We don't know how many users interact with interactive-examples, and how.

### Solution

Adds event listeners and posts messages to the parent (window) to measure interactions with interactive-examples.

**Note**: To distinguish the existing height-related message, this introduces the `type` key.

---

## How did you test this change?

1. In bob, checked out the PR (`gh pr checkout 1145`) and ran the build (`npm ci && npm run start`).
3. In yari, added the following environment variables to `.env`:
   ```
   BUILD_INTERACTIVE_EXAMPLES_BASE_URL=http://localhost:4444
   REACT_APP_INTERACTIVE_EXAMPLES_BASE_URL=http://localhost:4444
   ```
4. In yari, checked out this PR (`gh pr checkout 8337`) and ran the dev-build (`yarn && yarn dev`).
5. Opened http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/concat#try_it locally.
6. Clicked in the interactive example and executed several actions.
