### PR TITLE
fix: Refresh `invalid css` icon immediately after edit

### DIFF
--- a/editor/js/editor-libs/events.js
+++ b/editor/js/editor-libs/events.js
@@ -14,7 +14,7 @@ function addCSSEditorEventListeners(exampleChoiceList) {
 
     cssEditorUtils.applyCode(
       exampleChoiceParent.textContent,
-      exampleChoiceParent.closest(".cm-scroller")
+      exampleChoiceParent.closest(".example-choice")
     );
   });
 


### PR DESCRIPTION
Fixes #1138

That's how it looks like now:

https://user-images.githubusercontent.com/100634371/222924702-36dd73a9-8414-412d-aa3d-88f61ea90f37.mp4

