### PR TITLE
fix: Widen CSS example text area

### DIFF
--- a/editor/css/editable-css.css
+++ b/editor/css/editable-css.css
@@ -61,7 +61,7 @@
   position: relative;
   z-index: 1;
   display: block;
-  padding: 0 1rem;
+  padding: 0 12px;
   margin: 0.2em 0;
   width: 100%;
   border: 1px solid var(--border-primary);
@@ -83,7 +83,6 @@
   height: auto;
   text-align: left;
   padding: 4px 0;
-  padding-right: 1rem;
   background: none;
   border: none;
   font-size: 0.875rem;
@@ -91,6 +90,10 @@
 
 .live .example-choice .ͼ1.cm-editor.cm-focused {
   outline: none;
+}
+
+.cm-editor .cm-line {
+  padding: 0;
 }
 
 .example-choice-list .example-choice:first-child {


### PR DESCRIPTION
This PR decreases the amount of empty space on the sides of CSS declaration in CSS choice tabs.
Fixes #1127 (double background was already fixed in yari).

Before:
![image](https://user-images.githubusercontent.com/100634371/222925387-0ef4b916-c6ee-486d-8cdf-b6f69918f712.png)

After:
![image](https://user-images.githubusercontent.com/100634371/222925405-229c4fe2-0fc3-4bab-84d6-181cf7ebcfdc.png)