### PR TITLE
ci: Compile TS before running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
           node-version: 18
       - name: Install dependencies
         run: npm ci
+      - name: Prepack
+        run: npm run prepack
       - name: Build bob
         run: npm run build
       - name: Install developer dependencies


### PR DESCRIPTION
This change should fix recent test fails in #1171 and #1170 in which `.js` files cannot be found while running `npm run build`.