### PR TITLE
fix: Horizontal scrollbar obscures content

### DIFF
--- a/editor/css/editor-libs/codemirror-override.css
+++ b/editor/css/editor-libs/codemirror-override.css
@@ -19,6 +19,7 @@
 
 .cm-editor .cm-scroller {
   line-height: inherit;
+  padding-block: 1em;
 }
 
 .cm-editor .cm-cursor {


### PR DESCRIPTION
Fixes https://github.com/mdn/bob/issues/1249

Added `padding-block` to allow space for scrollbar.

**Firefox**

<img width="552" alt="Screenshot 2023-04-23 at 11 55 03" src="https://user-images.githubusercontent.com/6584854/233833342-5ab0b37c-a80c-4ab6-b578-e7041007ccee.png">

**Chrome**

![Screenshot 2023-04-23 at 11 54 38](https://user-images.githubusercontent.com/6584854/233833373-55bbe674-3cfa-4679-b687-5a0f183852e8.png)

**Safari**

<img width="552" alt="Screenshot 2023-04-23 at 11 55 03" src="https://user-images.githubusercontent.com/6584854/233833439-98e0cc60-f7b8-4577-8522-4a6090edbfba.png">

