### PR TITLE
feat(editor-libs): extend the feature detection for CSS functions

### DIFF
--- a/editor/js/editable-css.js
+++ b/editor/js/editable-css.js
@@ -1,6 +1,5 @@
 import * as clippy from "./editor-libs/clippy.js";
 import * as mceEvents from "./editor-libs/events.js";
-import * as mceUtils from "./editor-libs/mce-utils.js";
 import * as cssEditorUtils from "./editor-libs/css-editor-utils.js";
 import {
   initCodeEditor,

--- a/editor/js/editable-css.js
+++ b/editor/js/editable-css.js
@@ -14,7 +14,7 @@ import "../css/editable-css.css";
 (function () {
   const exampleChoiceList = document.getElementById("example-choice-list");
   const exampleChoices = exampleChoiceList.querySelectorAll(".example-choice");
-  const exampleChoiceTexts = Array.from(
+  const exampleDeclarations = Array.from(
     exampleChoices, (choice) => choice.querySelector("code").textContent);
   const editorWrapper = document.getElementById("editor-wrapper");
   const output = document.getElementById("output");
@@ -140,7 +140,7 @@ import "../css/editable-css.css";
     is a non standard object available only in IE10 and older,
     this will stop JS from executing in those versions. */
   if (
-    mceUtils.isPropertySupported(exampleChoiceList.dataset, exampleChoiceTexts) &&
+    mceUtils.isPropertySupported(exampleChoiceList.dataset, exampleDeclarations) &&
     !document.all
   ) {
     enableLiveEditor();

--- a/editor/js/editable-css.js
+++ b/editor/js/editable-css.js
@@ -10,12 +10,15 @@ import {
 import "../css/editor-libs/ui-fonts.css";
 import "../css/editor-libs/common.css";
 import "../css/editable-css.css";
+import { isAnyDeclarationSetSupported } from "./editor-libs/css-editor-utils.js";
 
 (function () {
   const exampleChoiceList = document.getElementById("example-choice-list");
   const exampleChoices = exampleChoiceList.querySelectorAll(".example-choice");
   const exampleDeclarations = Array.from(
-    exampleChoices, (choice) => choice.querySelector("code").textContent);
+    exampleChoices,
+    (choice) => choice.querySelector("code").textContent
+  );
   const editorWrapper = document.getElementById("editor-wrapper");
   const output = document.getElementById("output");
   const warningNoSupport = document.getElementById("warning-no-support");
@@ -140,7 +143,7 @@ import "../css/editable-css.css";
     is a non standard object available only in IE10 and older,
     this will stop JS from executing in those versions. */
   if (
-    mceUtils.isPropertySupported(exampleChoiceList.dataset, exampleDeclarations) &&
+    cssEditorUtils.isAnyDeclarationSetSupported(exampleDeclarations) &&
     !document.all
   ) {
     enableLiveEditor();

--- a/editor/js/editable-css.js
+++ b/editor/js/editable-css.js
@@ -10,7 +10,6 @@ import {
 import "../css/editor-libs/ui-fonts.css";
 import "../css/editor-libs/common.css";
 import "../css/editable-css.css";
-import { isAnyDeclarationSetSupported } from "./editor-libs/css-editor-utils.js";
 
 (function () {
   const exampleChoiceList = document.getElementById("example-choice-list");

--- a/editor/js/editable-css.js
+++ b/editor/js/editable-css.js
@@ -14,6 +14,8 @@ import "../css/editable-css.css";
 (function () {
   const exampleChoiceList = document.getElementById("example-choice-list");
   const exampleChoices = exampleChoiceList.querySelectorAll(".example-choice");
+  const exampleChoiceTexts = Array.from(
+    exampleChoices, (choice) => choice.querySelector("code").textContent);
   const editorWrapper = document.getElementById("editor-wrapper");
   const output = document.getElementById("output");
   const warningNoSupport = document.getElementById("warning-no-support");
@@ -138,7 +140,7 @@ import "../css/editable-css.css";
     is a non standard object available only in IE10 and older,
     this will stop JS from executing in those versions. */
   if (
-    mceUtils.isPropertySupported(exampleChoiceList.dataset) &&
+    mceUtils.isPropertySupported(exampleChoiceList.dataset, exampleChoiceTexts) &&
     !document.all
   ) {
     enableLiveEditor();

--- a/editor/js/editor-libs/css-editor-utils.js
+++ b/editor/js/editor-libs/css-editor-utils.js
@@ -38,6 +38,15 @@ export function applyCode(code, choice, targetElement, immediateInvalidChange) {
 }
 
 /**
+ * Creates a temporary element and tests whether any of the provided CSS sets of declarations are fully supported by the user's browser
+ * @param {Array} declarationSets - Array in which every element is one or multiple declarations separated by semicolons
+ */
+export function isAnyDeclarationSetSupported(declarationSets) {
+  const tmpElem = document.createElement("div");
+  return declarationSets.some(isCodeSupported.bind(null, tmpElem));
+}
+
+/**
  * Checks if every passed declaration is supported by the browser.
  * In case browser recognizes property with vendor prefix(like -webkit-), lacking support for unprefixed property is ignored.
  * Properties with vendor prefix not recognized by the browser are always ignored.

--- a/editor/js/editor-libs/mce-utils.js
+++ b/editor/js/editor-libs/mce-utils.js
@@ -1,3 +1,5 @@
+import { isCodeSupported } from "./css-editor-utils.js";
+
 /**
  * Find and return the `example-choice` parent of the provided element
  * @param {Object} element - The child element for which to find the
@@ -21,30 +23,20 @@ export function findParentChoiceElem(element) {
  * Creates a temporary element and tests whether the passed
  * property exists on the `style` property of the element.
  * @param {Object} dataset - The dataset from which to get the property
- * @param {Array} texts - The choice texts containing the property
+ * @param {Array} declarations - The declarations containing the property
  */
-export function isPropertySupported(dataset, texts) {
+export function isPropertySupported(dataset, declarations) {
   /* If there are no 'property' attributes,
            there is nothing to test, so return true. */
   if (dataset["property"] === undefined) {
     return true;
   }
 
-  // `property` may be a space-separated list of properties.
-  const properties = dataset["property"].split(" ");
-  /* Iterate through properties:
-        if any of them applies and has a valid value,
+  /* Iterate through declarations: if any of them is valid,
         the browser supports this example. */
   const tmpElem = document.createElement("div");
 
-  for (const text in texts) {
-    tmpElem.style = text;
-    if (properties.some((property) => tmpElem.style[property])) {
-      return true;
-    }
-  }
-
-  return false;
+  return declarations.some(isCodeSupported.bind(null, tmpElem));
 }
 
 /**

--- a/editor/js/editor-libs/mce-utils.js
+++ b/editor/js/editor-libs/mce-utils.js
@@ -20,9 +20,10 @@ export function findParentChoiceElem(element) {
 /**
  * Creates a temporary element and tests whether the passed
  * property exists on the `style` property of the element.
- * @param {Object} dataset = The dataset from which to get the property
+ * @param {Object} dataset - The dataset from which to get the property
+ * @param {Array} texts - The choice texts containing the property
  */
-export function isPropertySupported(dataset) {
+export function isPropertySupported(dataset, texts) {
   /* If there are no 'property' attributes,
            there is nothing to test, so return true. */
   if (dataset["property"] === undefined) {
@@ -36,8 +37,9 @@ export function isPropertySupported(dataset) {
         the browser supports this example. */
   const tmpElem = document.createElement("div");
 
-  for (const property of properties) {
-    if (tmpElem.style[property]) {
+  for(const text in texts) {
+    tmpElem.style = text;
+    if (properties.some((property) => tmpElem.style[property])) {
       return true;
     }
   }

--- a/editor/js/editor-libs/mce-utils.js
+++ b/editor/js/editor-libs/mce-utils.js
@@ -1,5 +1,3 @@
-import { isCodeSupported } from "./css-editor-utils.js";
-
 /**
  * Find and return the `example-choice` parent of the provided element
  * @param {Object} element - The child element for which to find the
@@ -18,27 +16,6 @@ export function findParentChoiceElem(element) {
   }
   return parent;
 }
-
-/**
- * Creates a temporary element and tests whether the passed
- * property exists on the `style` property of the element.
- * @param {Object} dataset - The dataset from which to get the property
- * @param {Array} declarations - The declarations containing the property
- */
-export function isPropertySupported(dataset, declarations) {
-  /* If there are no 'property' attributes,
-           there is nothing to test, so return true. */
-  if (dataset["property"] === undefined) {
-    return true;
-  }
-
-  /* Iterate through declarations: if any of them is valid,
-        the browser supports this example. */
-  const tmpElem = document.createElement("div");
-
-  return declarations.some(isCodeSupported.bind(null, tmpElem));
-}
-
 /**
  * Interrupts the default click event on external links inside
  * the iframe and opens them in a new tab instead

--- a/editor/js/editor-libs/mce-utils.js
+++ b/editor/js/editor-libs/mce-utils.js
@@ -37,7 +37,7 @@ export function isPropertySupported(dataset, texts) {
         the browser supports this example. */
   const tmpElem = document.createElement("div");
 
-  for(const text in texts) {
+  for (const text in texts) {
     tmpElem.style = text;
     if (properties.some((property) => tmpElem.style[property])) {
       return true;

--- a/editor/js/editor-libs/mce-utils.js
+++ b/editor/js/editor-libs/mce-utils.js
@@ -31,18 +31,18 @@ export function isPropertySupported(dataset) {
 
   // `property` may be a space-separated list of properties.
   const properties = dataset["property"].split(" ");
-  /* Iterate through properties: if any of them apply,
+  /* Iterate through properties:
+        if any of them applies and has a valid value,
         the browser supports this example. */
   const tmpElem = document.createElement("div");
-  let supported = false;
 
-  for (let i = 0, l = properties.length; i < l; i++) {
-    if (tmpElem.style[properties[i]] !== undefined) {
-      supported = true;
+  for (const property of properties) {
+    if (tmpElem.style[property]) {
+      return true;
     }
   }
 
-  return supported;
+  return false;
 }
 
 /**


### PR DESCRIPTION
This PR extends the `isPropertySupported()` function to detect browsers' supports for CSS functions. Its validity can be *deduced* as below:

  1. If `property` is not supported, then `tmpElem.style[property]` is `undefined`.
  2. If `property` is supported but the value in the example is not, then `tmpElem.style[property]` is `""`.
  3. If both `property` and the value are supported, then `tmpElem.style[property]` is a non-empty string.

---

Fixes #1269.