### PR TITLE
fix: remove search functionality from code editor

### DIFF
--- a/editor/js/editor-libs/codemirror-editor.js
+++ b/editor/js/editor-libs/codemirror-editor.js
@@ -11,7 +11,6 @@ import {
   LRLanguage,
 } from "@codemirror/language";
 import { closeBrackets, closeBracketsKeymap } from "@codemirror/autocomplete";
-import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
 import { lintKeymap } from "@codemirror/lint";
 import { javascript, javascriptLanguage } from "@codemirror/lang-javascript";
 import { wast } from "@codemirror/lang-wast";
@@ -199,11 +198,9 @@ const BASE_EXTENSIONS = [
   closeBrackets(),
   view.rectangularSelection(),
   view.crosshairCursor(),
-  highlightSelectionMatches(),
   view.keymap.of([
     ...closeBracketsKeymap,
     ...commands.defaultKeymap,
-    ...searchKeymap,
     ...commands.historyKeymap,
     ...foldKeymap,
     ...lintKeymap,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@codemirror/lang-wast": "^6.0.0",
         "@codemirror/language": "^6.2.1",
         "@codemirror/lint": "^6.0.0",
-        "@codemirror/search": "^6.2.1",
         "@codemirror/view": "^6.3.0",
         "@lezer/common": "^1.0.1",
         "@lezer/css": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "@codemirror/lang-wast": "^6.0.0",
     "@codemirror/language": "^6.2.1",
     "@codemirror/lint": "^6.0.0",
-    "@codemirror/search": "^6.2.1",
     "@codemirror/view": "^6.3.0",
     "@lezer/common": "^1.0.1",
     "@lezer/css": "^1.0.0",


### PR DESCRIPTION
This PR fixes https://github.com/mdn/bob/issues/1258 by removing CodeMirror's search package.  The amount of code that we have in our interactive examples is far smaller than anything that would need its own dedicated search, so having it makes zero sense (and in fact breaks things).
