### PR TITLE
Ignore built TypeScript files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ typings/
 
 # project specific
 /docs/
+
+# Built TypeScript files
+lib/*.js
+webpack.config.js


### PR DESCRIPTION
This PR ignores the built TypeScript files in `lib/` and the project root.
