### PR TITLE
fix(js): remove unused placeholders

### DIFF
--- a/editor/tmpl/live-js-tmpl.html
+++ b/editor/tmpl/live-js-tmpl.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link href="../../css/codemirror.css%cache-buster%" rel="stylesheet" />
     <link href="../../css/editor-js.css%cache-buster%" rel="stylesheet" />
-    %example-css-src%
   </head>
 
   <body>
@@ -29,8 +28,6 @@
         <div id="console" class="output"><code></code></div>
       </div>
     </section>
-
-    %example-js-src%
 
     <script src="../../js/codemirror.js%cache-buster%"></script>
     <script src="../../js/editor-js.js%cache-buster%"></script>


### PR DESCRIPTION
Removes unused placeholders. JavaScript examples don't have `cssExampleSrc` and `jsExampleSrc` in their `meta.json`, only CSS examples have these.

Noticed as part of reviewing https://github.com/mdn/bob/pull/1164, which removes one of these.

## Screenshots

| Before | After |
|--------|--------|
| <img width="701" alt="image" src="https://github.com/mdn/bob/assets/495429/153ddc62-0164-4a27-aa4a-fb67a39bf970"> | <img width="701" alt="image" src="https://github.com/mdn/bob/assets/495429/5d5a38ab-25f1-4fed-b190-5eac91973c05"> |

