### PR TITLE
chore: remove Internet Explorer detection

### DIFF
--- a/editor/js/editable-css.js
+++ b/editor/js/editable-css.js
@@ -138,14 +138,8 @@ import "../css/editable-css.css";
     }
   }
 
-  /* only show the live code view if JS is enabled and the property is supported.
-    Also, only execute JS in our supported browsers. As `document.all`
-    is a non standard object available only in IE10 and older,
-    this will stop JS from executing in those versions. */
-  if (
-    cssEditorUtils.isAnyDeclarationSetSupported(exampleDeclarations) &&
-    !document.all
-  ) {
+  /* only show the live code view if JS is enabled and the property is supported. */
+  if (cssEditorUtils.isAnyDeclarationSetSupported(exampleDeclarations)) {
     enableLiveEditor();
     mceEvents.onChoose(exampleChoices[initialChoice]);
     clippy.toggleClippy(exampleChoices[initialChoice]);

--- a/editor/js/editable-js.js
+++ b/editor/js/editable-js.js
@@ -88,10 +88,7 @@ import {
     );
   }
 
-  /* only execute JS in supported browsers. As `document.all`
-    is a non standard object available only in IE10 and older,
-    this will stop JS from executing in those versions. */
-  if (!document.all && featureDetector.isDefined(exampleFeature)) {
+  if (featureDetector.isDefined(exampleFeature)) {
     document.documentElement.classList.add("js");
 
     initInteractiveEditor();


### PR DESCRIPTION
This PR removes bad browser support detection from the JavaScript editor.  There is a clause that checks if `document.all` is supported, assuming that IE10 and earlier are the only browsers that support it (and that it is non-standard).  This assumption is false, however (see https://developer.mozilla.org/en-US/docs/Web/API/Document/all#Browser_compatibility); all modern browsers support it (and it is a part of the HTML standard).  Additionally, `document.all` is interestingly falsy in browsers (`!!document.all == false`), so the code within the `if` block was running anyways.

Note: we can also just consider this code removal as dropping IE support!