### PR TITLE
fix(publish-release): add permissions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   publish-release:
     if: github.repository == 'mdn/bob'


### PR DESCRIPTION
This ensures the workflow can also run on merge commits by @mdn-bot.

See [in rumba](https://github.com/mdn/rumba/blob/deb9d5443d4c9e338a6e16fdd94bb6f8bfecebda/.github/workflows/release-please.yml#L6-L8) and [in yari](https://github.com/mdn/yari/blob/6e6ed7873373e35d720922b5924a0537566b4851/.github/workflows/npm-publish.yml#L8-L10).