### PR TITLE
fix(gitignore): ignore VSCode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ lib/*.js
 lib/*.js.map
 editor/**/*.js
 editor/**/*.js.map
+
+# misc
+.idea/


### PR DESCRIPTION
See also [in yari](https://github.com/mdn/yari/blob/6e6ed7873373e35d720922b5924a0537566b4851/.gitignore#L24), for example.