### PR TITLE
fix(publish-release): add --access + unquote token

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,6 +34,6 @@ jobs:
 
       - name: Publish
         if: steps.release.outputs.release_created
-        run: npm publish
+        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: "${{secrets.NPM_AUTH_TOKEN}}"
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
Mirrors the corresponding lines in [the bcd-utils workflow](https://github.com/mdn/bcd-utils/blob/d90fffa351cb1594a9155f5b6d4d67cbd71ec852/.github/workflows/publish-package-api.yml#L30C25-L32).