### PR TITLE
fix(scripts): specify ts-node via NODE_OPTIONS

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     }
   ],
   "scripts": {
-    "build": "ts-node ./lib/mdn-bob.ts",
-    "build:pages": "ts-node ./lib/mdn-bob.ts --skip-webpack",
+    "build": "cross-env NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node ./lib/mdn-bob.ts",
+    "build:pages": "cross-env NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' node ./lib/mdn-bob.ts --skip-webpack",
     "prepack": "tsc",
     "start": "npm-run-all build start-server",
     "start-server": "http-server -p 4444 ./docs",


### PR DESCRIPTION
Resolves the following error with Node 18.19+:

```
% yarn build                                                                                          130 ↵
yarn run v1.22.22
$ ts-node ./lib/mdn-bob.ts
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /path/to/mdn/bob/lib/mdn-bob.ts
    at new NodeError (node:internal/errors:405:5)
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:136:11)
    at defaultGetFormat (node:internal/modules/esm/get_format:182:36)
    at defaultLoad (node:internal/modules/esm/load:101:20)
    at nextLoad (node:internal/modules/esm/hooks:864:28)
    at load (/path/to/mdn/bob/node_modules/ts-node/dist/child/child-loader.js:19:122)
    at nextLoad (node:internal/modules/esm/hooks:864:28)
    at Hooks.load (node:internal/modules/esm/hooks:447:26)
    at MessagePort.handleMessage (node:internal/modules/esm/worker:196:24)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:786:20) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}
```